### PR TITLE
[#29] Input 컴포넌트 구현 v1.0.0

### DIFF
--- a/src/components/common/Input/Input.style.ts
+++ b/src/components/common/Input/Input.style.ts
@@ -1,0 +1,39 @@
+import styled from 'styled-components';
+
+import { InputStyledProps } from './Input.type';
+
+export const InputWrapper = styled.div<InputStyledProps>`
+  width: ${(props) => props.$width};
+  font-size: ${(props) => props.$fontSize}rem;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const Label = styled.label<InputStyledProps>`
+  color: ${({ theme }) => theme.primary_color};
+  margin-bottom: ${(props) => (props.$margin ? props.$margin : 1.5)}rem;
+`;
+
+export const StyledInput = styled.input`
+  color: ${({ theme }) => theme.primary_color};
+  background-color: transparent;
+  padding: 0 0.4rem 0.2rem 0.4rem;
+  box-sizing: border-box;
+  border: none;
+  border-bottom: 0.15rem solid ${({ theme }) => theme.primary_color};
+  outline: none;
+  transition: border 0.3s;
+
+  &:focus {
+    border-bottom: 0.15rem solid ${({ theme }) => theme.symbol_secondary_color};
+  }
+
+  &::placeholder {
+    color: ${({ theme }) => theme.gray_300};
+  }
+`;
+
+export const ErrorMessage = styled.div<InputStyledProps>`
+  color: ${({ theme }) => theme.error_red};
+  margin-top: ${(props) => (props.$margin ? props.$margin + 0.15 : 1.65)}rem;
+`;

--- a/src/components/common/Input/Input.style.ts
+++ b/src/components/common/Input/Input.style.ts
@@ -6,7 +6,7 @@ import { InputStyledProps } from './Input.type';
 
 export const InputWrapper = styled(Col)<InputStyledProps>`
   width: ${(props) => props.$width};
-  font-size: ${(props) => (props.$fontSize ? props.$fontSize : 2)}rem;
+  font-size: ${(props) => (props.$fontSize ? props.$fontSize : 1.6)}rem;
 `;
 
 export const Label = styled.label<InputStyledProps>`

--- a/src/components/common/Input/Input.style.ts
+++ b/src/components/common/Input/Input.style.ts
@@ -36,4 +36,5 @@ export const StyledInput = styled.input`
 export const ErrorMessage = styled.div<InputStyledProps>`
   color: ${({ theme }) => theme.error_red};
   margin-top: ${(props) => (props.$margin ? props.$margin + 0.15 : 1.65)}rem;
+  visibility: ${({ $isError }) => ($isError ? 'hidden' : undefined)};
 `;

--- a/src/components/common/Input/Input.style.ts
+++ b/src/components/common/Input/Input.style.ts
@@ -4,7 +4,7 @@ import { InputStyledProps } from './Input.type';
 
 export const InputWrapper = styled.div<InputStyledProps>`
   width: ${(props) => props.$width};
-  font-size: ${(props) => props.$fontSize}rem;
+  font-size: ${(props) => (props.$fontSize ? props.$fontSize : 2)}rem;
   display: flex;
   flex-direction: column;
 `;

--- a/src/components/common/Input/Input.style.ts
+++ b/src/components/common/Input/Input.style.ts
@@ -22,7 +22,7 @@ export const StyledInput = styled.input`
   border: none;
   border-bottom: 0.15rem solid ${({ theme }) => theme.primary_color};
   outline: none;
-  transition: border 0.3s;
+  transition: border 0.2s;
 
   &:focus {
     border-bottom: 0.15rem solid ${({ theme }) => theme.symbol_secondary_color};

--- a/src/components/common/Input/Input.style.ts
+++ b/src/components/common/Input/Input.style.ts
@@ -34,6 +34,7 @@ export const StyledInput = styled.input`
 `;
 
 export const ErrorMessage = styled.div<InputStyledProps>`
+  font-size: ${(props) => (props.$fontSize ? props.$fontSize - 0.6 : 1)}rem;
   color: ${({ theme }) => theme.error_red};
   margin-top: ${(props) => (props.$margin ? props.$margin + 0.15 : 1.65)}rem;
   visibility: ${({ $isError }) => ($isError ? 'hidden' : undefined)};

--- a/src/components/common/Input/Input.style.ts
+++ b/src/components/common/Input/Input.style.ts
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
 
+import { Col } from '@/styles/globalStyles';
+
 import { InputStyledProps } from './Input.type';
 
-export const InputWrapper = styled.div<InputStyledProps>`
+export const InputWrapper = styled(Col)<InputStyledProps>`
   width: ${(props) => props.$width};
   font-size: ${(props) => (props.$fontSize ? props.$fontSize : 2)}rem;
-  display: flex;
-  flex-direction: column;
 `;
 
 export const Label = styled.label<InputStyledProps>`

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -18,7 +18,7 @@ import { InputProps } from './Input.type';
  * @param margin : 선택 | number 타입. 라벨, input, 에러 메시지 간 간격을 의미. 생략 시 기본 값으로 1.5가 설정. (단위는 rem)
  * @param label : 선택 | string 타입. input 위에 붙는 라벨 역할.
  * @param placeholder : 선택 | string 타입. input의 placeholder 역할.
- * @param errorMessage : 선택 | string 타입. input의 placeholder 역할.
+ * @param errorMessage : 선택 | string 타입. input의 에러 메시지 역할.
  * @param ...props : 커스텀을 위함 (+ react-hook-form)
  * @returns
  */

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -42,7 +42,9 @@ const Input = ({
         placeholder={placeholder}
         {...props}
       />
-      <ErrorMessage $margin={margin}>{errorMessage}</ErrorMessage>
+      {errorMessage && (
+        <ErrorMessage $margin={margin}>{errorMessage}</ErrorMessage>
+      )}
     </InputWrapper>
   );
 };

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -42,9 +42,12 @@ const Input = ({
         placeholder={placeholder}
         {...props}
       />
-      {errorMessage && (
-        <ErrorMessage $margin={margin}>{errorMessage}</ErrorMessage>
-      )}
+      <ErrorMessage
+        $isError={errorMessage?.length === 0}
+        $margin={margin}
+      >
+        {errorMessage?.length === 0 ? 'no Error' : errorMessage}
+      </ErrorMessage>
     </InputWrapper>
   );
 };

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -43,6 +43,7 @@ const Input = ({
         {...props}
       />
       <ErrorMessage
+        $fontSize={fontSize}
         $isError={errorMessage?.length === 0}
         $margin={margin}
       >

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -14,7 +14,8 @@ import { InputProps } from './Input.type';
         errorMessage={'에러다'}
       />
  * @param width : 필수 | string 타입. input의 너비를 의미함. (px or rem or % 로 기입)
- * @param fontSize : 선택 | number 타입. 라벨, input, 에러 메시지의 폰트 사이즈를 의미. 생략 시 기본 값으로 2가 설정. (단위는 rem)
+ * @param fontSize : 선택 | number 타입. 라벨, input, 에러 메시지의 폰트 사이즈를 의미. 생략 시 기본 값으로 1.6이 설정. 
+ * 에러 메시지는 기본값이 1로 설정되며 fontSize props를 넘겨준 경우에 에러 메시지 폰트 사이즈는 (fontSize - 0.6) rem 만큼 설정됨. (단위는 rem)
  * @param margin : 선택 | number 타입. 라벨, input, 에러 메시지 간 간격을 의미. 생략 시 기본 값으로 1.5가 설정. (단위는 rem)
  * @param label : 선택 | string 타입. input 위에 붙는 라벨 역할.
  * @param placeholder : 선택 | string 타입. input의 placeholder 역할.

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -1,6 +1,28 @@
 import { ErrorMessage, InputWrapper, Label, StyledInput } from './Input.style';
 import { InputProps } from './Input.type';
 
+/**
+ *
+ * @description 공통 Input 컴포넌트
+ * @summary 사용법 :
+ * <Input
+        width={'50rem'}
+        fontSize={2}
+        margin={1.5}
+        label={'라벨이다'}
+        placeholder={'닉네임 써라'}
+        errorMessage={'에러다'}
+      />
+ * @param width : 필수 | string 타입. input의 너비를 의미함. (px or rem or % 로 기입)
+ * @param fontSize : 선택 | number 타입. 라벨, input, 에러 메시지의 폰트 사이즈를 의미. 생략 시 기본 값으로 2가 설정. (단위는 rem)
+ * @param margin : 선택 | number 타입. 라벨, input, 에러 메시지 간 간격을 의미. 생략 시 기본 값으로 1.5가 설정. (단위는 rem)
+ * @param label : 선택 | string 타입. input 위에 붙는 라벨 역할.
+ * @param placeholder : 선택 | string 타입. input의 placeholder 역할.
+ * @param errorMessage : 선택 | string 타입. input의 placeholder 역할.
+ * @param ...props : 커스텀을 위함 (+ react-hook-form)
+ * @returns
+ */
+
 const Input = ({
   width,
   fontSize,
@@ -8,6 +30,7 @@ const Input = ({
   label,
   placeholder,
   errorMessage,
+  ...props
 }: InputProps) => {
   return (
     <InputWrapper
@@ -15,7 +38,10 @@ const Input = ({
       $fontSize={fontSize}
     >
       <Label $margin={margin}>{label}</Label>
-      <StyledInput placeholder={placeholder} />
+      <StyledInput
+        placeholder={placeholder}
+        {...props}
+      />
       <ErrorMessage $margin={margin}>{errorMessage}</ErrorMessage>
     </InputWrapper>
   );

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -1,5 +1,24 @@
-const Input = () => {
-  return <div>인풋 컴포넌트</div>;
+import { ErrorMessage, InputWrapper, Label, StyledInput } from './Input.style';
+import { InputProps } from './Input.type';
+
+const Input = ({
+  width,
+  fontSize,
+  margin,
+  label,
+  placeholder,
+  errorMessage,
+}: InputProps) => {
+  return (
+    <InputWrapper
+      $width={width}
+      $fontSize={fontSize}
+    >
+      <Label $margin={margin}>{label}</Label>
+      <StyledInput placeholder={placeholder} />
+      <ErrorMessage $margin={margin}>{errorMessage}</ErrorMessage>
+    </InputWrapper>
+  );
 };
 
 export default Input;

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -1,0 +1,5 @@
+const Input = () => {
+  return <div>인풋 컴포넌트</div>;
+};
+
+export default Input;

--- a/src/components/common/Input/Input.type.ts
+++ b/src/components/common/Input/Input.type.ts
@@ -11,4 +11,5 @@ export interface InputStyledProps {
   $width?: string;
   $fontSize?: number;
   $margin?: number;
+  $isError?: boolean;
 }

--- a/src/components/common/Input/Input.type.ts
+++ b/src/components/common/Input/Input.type.ts
@@ -1,6 +1,6 @@
 export interface InputProps extends React.HTMLAttributes<HTMLInputElement> {
   width: string;
-  fontSize: number;
+  fontSize?: number;
   margin?: number;
   label?: string;
   placeholder?: string;

--- a/src/components/common/Input/Input.type.ts
+++ b/src/components/common/Input/Input.type.ts
@@ -1,0 +1,14 @@
+export interface InputProps extends React.HTMLAttributes<HTMLInputElement> {
+  width: string;
+  fontSize: number;
+  margin?: number;
+  label?: string;
+  placeholder?: string;
+  errorMessage?: string;
+}
+
+export interface InputStyledProps {
+  $width?: string;
+  $fontSize?: number;
+  $margin?: number;
+}

--- a/src/components/common/Input/index.ts
+++ b/src/components/common/Input/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Input';

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -16,6 +16,7 @@ export const lightTheme: object = {
   gray_100: '#D9D9D9',
 
   // 확장, 추가 시 PR에 명시
+  error_red: '#F82B2B',
 };
 
 export const darkTheme: object = {
@@ -37,6 +38,7 @@ export const darkTheme: object = {
   gray_100: '#D9D9D9',
 
   // 확장, 추가 시 PR에 명시
+  error_red: '#F84A4A',
 };
 
 const Theme = {


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용

공통 컴포넌트인 Input 컴포넌트를 구현했습니다.

# 📷스크린샷(필요 시)

![스크린샷 2024-02-15 오후 6 24 56](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/79b498f7-e057-4aac-835c-57724d6ec10b)
![스크린샷 2024-02-15 오후 6 26 08](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/a36d142a-8267-4815-a8f3-c1922df4b2cf)

# 사용 방법

```typescript

      <Input
        width={'20rem'}
        fontSize={2}
        margin={1.5}
        label={'라벨이다'}
        placeholder={'닉네임 써라'}
        errorMessage={'에러다'}
        {...props} // 추가 props들
      />

```

- `Input` 컴포넌트에서 필수 props는 `width`입니다.
  - `width`는 string 타입이며, px, rem, %를 다 받을수 있도록 구현했습니다.

- `Input` 컴포넌트에서 선택 props는 `fontSize`, `margin`, `label`, `placeholder`, `errorMessage` 입니다.
  - `fontSize`는 number 타입이며, 라벨, input, 에러 메시지의 폰트 사이즈를 의미합니다. 생략 시 기본 값으로 `2`가 설정됩니다. (단위는 rem)
  - `margin`은 number 타입이며, 라벨, input, 에러 메시지 간 간격을 의미합니다. 생략 시 기본 값으로 `1.5`가 설정 됩니다. (단위는 rem)
  - `label`은 string 타입이며, input 위에 붙는 라벨 역할을 합니다.
  - `placrholder`는 string 타입이며, input의 placeholder 역할을 합니다.
  - `errorMessage`는 string 타입이며, input 하단 에러 메시지 역할을 합니다.

# ✨PR Point

- `styles > theme.ts` 파일에 `error_red` 색상을 추가하였습니다. 라이트 모드일 때는 `#F82B2B` 이며, 다크 모드일 때는 `#F84A4A` 입니다.
  - 모드에 따라 색상 코드가 다른 이유는 제 눈에는 다크 모드에서 빨간색이 잘 안보여서 라이트 모드일 때보다 조금 밝은 색을 적용해봤습니다 !!

## react-hook-form 고려
- `react-hook-form` 도입을 고려하여 Input 컴포넌트 내에 `{...props}`을 두었습니다. 
react-hook-form을 위해 추가로 작업해야 할 사항이 있을까요 ?