### PR TITLE
[#38] Button(사각형) 컴포넌트 구현 v1.0.0

### DIFF
--- a/src/components/common/Button/Button.style.ts
+++ b/src/components/common/Button/Button.style.ts
@@ -29,13 +29,13 @@ const StyledButton = styled.button<StyledButtonProps>`
 
   &:disabled {
     cursor: not-allowed;
-    background-color: ${(props) => props.$textColor};
-    border: 1px solid ${(props) => props.$backgroundColor};
-    color: ${(props) => props.$backgroundColor};
+    background-color: ${({ theme }) => theme.gray_300};
+    border: none;
+    color: white;
   }
 
   @media screen and (max-width: ${MOBILE}px) {
-    font-size: calc(${(props) => props.$textSize} - 0.3rem);
+    font-size: calc(${(props) => props.$textSize} - 0.2rem);
   }
 
   &:active {

--- a/src/components/common/Button/Button.style.ts
+++ b/src/components/common/Button/Button.style.ts
@@ -16,7 +16,7 @@ const StyledButton = styled.button<StyledButtonProps>`
   border-radius: 0.6rem;
   border: 1px solid ${(props) => props.$borderColor};
 
-  transition: all 0.3s ease;
+  transition: all 0.2s ease;
 
   &:hover {
     background-color: ${(props) => props.$hoverBackgroundColor};

--- a/src/components/common/Button/Button.style.ts
+++ b/src/components/common/Button/Button.style.ts
@@ -1,0 +1,34 @@
+import { styled } from 'styled-components';
+
+import type { StyledButtonProps } from './Button.type';
+
+const StyledButton = styled.button<StyledButtonProps>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  background-color: ${(props) => props.$backgroundColor};
+  color: ${(props) => props.$textColor};
+  font-size: ${(props) => props.$textSize};
+
+  width: ${(props) => props.$width};
+  height: ${(props) => props.$height};
+  border-radius: 0.6rem;
+  border: 1px solid ${(props) => props.$borderColor};
+
+  transition: all 0.3s ease;
+
+  &:hover {
+    background-color: ${(props) => props.$hoverBackgroundColor};
+    color: ${(props) => props.$hoverTextColor};
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    background-color: ${(props) => props.$textColor};
+    border: 1px solid ${(props) => props.$backgroundColor};
+    color: ${(props) => props.$backgroundColor};
+  }
+`;
+
+export default StyledButton;

--- a/src/components/common/Button/Button.style.ts
+++ b/src/components/common/Button/Button.style.ts
@@ -1,4 +1,6 @@
-import { styled } from 'styled-components';
+import { css, styled } from 'styled-components';
+
+import { MOBILE } from '@/constants';
 
 import type { StyledButtonProps } from './Button.type';
 
@@ -18,9 +20,11 @@ const StyledButton = styled.button<StyledButtonProps>`
 
   transition: all 0.2s ease;
 
-  &:hover {
-    background-color: ${(props) => props.$hoverBackgroundColor};
-    color: ${(props) => props.$hoverTextColor};
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      background-color: ${(props) => props.$hoverBackgroundColor};
+      color: ${(props) => props.$hoverTextColor};
+    }
   }
 
   &:disabled {
@@ -29,6 +33,23 @@ const StyledButton = styled.button<StyledButtonProps>`
     border: 1px solid ${(props) => props.$backgroundColor};
     color: ${(props) => props.$backgroundColor};
   }
+
+  @media screen and (max-width: ${MOBILE}px) {
+    font-size: calc(${(props) => props.$textSize} - 0.3rem);
+  }
+
+  &:active {
+    ${(props) => {
+      if (props.$isActive) {
+        return css`
+          background-color: ${props.$hoverBackgroundColor};
+          color: ${props.$hoverTextColor};
+        `;
+      }
+    }}
+  }
+
+  -webkit-tap-highlight-color: transparent;
 `;
 
 export default StyledButton;

--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -6,8 +6,20 @@ import { ButtonProps } from './Button.type';
 
 /**
  * @brief 범용적으로 사용할 수 있는 사각형 버튼입니다.
- * @param width px,rem,% 단위 커스텀 가능
- * @param height px,rem,% 단위 커스텀 가능
+ * @param width px,rem,% 등 자유롭게 단위 커스텀 가능합니다.
+ * @param height px,rem,% 등 자유롭게 단위 커스텀 가능합니다.
+ * @detail 버튼의 비활성화/활성화 기능을 사용하시려면 isActive, disabled 속성을 둘 다 사용해야 합니다.
+ * @param disabled 버튼이 비활성화되는 조건이 될 boolean 값을 넣습니다.
+ * @param isActive disabled과 반대되는 boolean 값을 넣습니다.
+ * @summary 사용법)
+    const [isActive, setIsActive] = useState(false);
+    <Button
+      disabled={!isActive}
+      isActive={isActive}
+    >
+      로그인
+    </Button>
+ * @param textSize 모바일 환경에서는 설정한 값에서 0.3rem을 뺀 크기로 자동 보정됩니다.
  */
 const Button = ({
   width = '10rem',
@@ -18,6 +30,7 @@ const Button = ({
   hoverBackgroundColor,
   hoverTextColor,
   borderColor,
+  isActive = true,
   children,
   ...props
 }: PropsWithChildren<ButtonProps>) => {
@@ -35,6 +48,7 @@ const Button = ({
       }
       $hoverTextColor={hoverTextColor || theme.secondary_color}
       $borderColor={borderColor || undefined}
+      $isActive={isActive}
       {...props}
     >
       {children}

--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -4,6 +4,11 @@ import { useTheme } from 'styled-components';
 import StyledButton from './Button.style';
 import { ButtonProps } from './Button.type';
 
+/**
+ * @brief 범용적으로 사용할 수 있는 사각형 버튼입니다.
+ * @param width px,rem,% 단위 커스텀 가능
+ * @param height px,rem,% 단위 커스텀 가능
+ */
 const Button = ({
   width = '10rem',
   height = '3rem',

--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -1,0 +1,40 @@
+import { PropsWithChildren } from 'react';
+import { useTheme } from 'styled-components';
+
+import StyledButton from './Button.style';
+import { ButtonProps } from './Button.type';
+
+const Button = ({
+  width = '10rem',
+  height = '3rem',
+  backgroundColor,
+  textColor,
+  textSize = '1.3rem',
+  hoverBackgroundColor,
+  hoverTextColor,
+  borderColor,
+  children,
+  ...props
+}: PropsWithChildren<ButtonProps>) => {
+  const theme = useTheme();
+
+  return (
+    <StyledButton
+      $width={width}
+      $height={height}
+      $backgroundColor={backgroundColor || theme.symbol_color}
+      $textColor={textColor || theme.background_color}
+      $textSize={textSize}
+      $hoverBackgroundColor={
+        hoverBackgroundColor || theme.symbol_secondary_color
+      }
+      $hoverTextColor={hoverTextColor || theme.secondary_color}
+      $borderColor={borderColor || undefined}
+      {...props}
+    >
+      {children}
+    </StyledButton>
+  );
+};
+
+export default Button;

--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -1,4 +1,3 @@
-import { PropsWithChildren } from 'react';
 import { useTheme } from 'styled-components';
 
 import StyledButton from './Button.style';
@@ -22,18 +21,18 @@ import { ButtonProps } from './Button.type';
  * @param textSize 모바일 환경에서는 설정한 값에서 0.3rem을 뺀 크기로 자동 보정됩니다.
  */
 const Button = ({
-  width = '10rem',
-  height = '3rem',
+  width = '12rem',
+  height = '3.5rem',
   backgroundColor,
+  text,
   textColor,
-  textSize = '1.3rem',
+  textSize = '1.6rem',
   hoverBackgroundColor,
   hoverTextColor,
   borderColor,
   isActive = true,
-  children,
   ...props
-}: PropsWithChildren<ButtonProps>) => {
+}: ButtonProps) => {
   const theme = useTheme();
 
   return (
@@ -51,7 +50,7 @@ const Button = ({
       $isActive={isActive}
       {...props}
     >
-      {children}
+      {text}
     </StyledButton>
   );
 };

--- a/src/components/common/Button/Button.type.ts
+++ b/src/components/common/Button/Button.type.ts
@@ -9,6 +9,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   hoverBackgroundColor?: string;
   hoverTextColor?: string;
   borderColor?: string;
+  isActive?: boolean;
 }
 
 export interface StyledButtonProps
@@ -21,4 +22,5 @@ export interface StyledButtonProps
   $hoverBackgroundColor: string;
   $hoverTextColor: string;
   $borderColor?: string;
+  $isActive?: boolean;
 }

--- a/src/components/common/Button/Button.type.ts
+++ b/src/components/common/Button/Button.type.ts
@@ -3,6 +3,7 @@ import { ButtonHTMLAttributes } from 'react';
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   width?: string;
   height?: string;
+  text: string;
   backgroundColor?: string;
   textColor?: string;
   textSize?: string;

--- a/src/components/common/Button/Button.type.ts
+++ b/src/components/common/Button/Button.type.ts
@@ -1,0 +1,24 @@
+import { ButtonHTMLAttributes } from 'react';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  width?: string;
+  height?: string;
+  backgroundColor?: string;
+  textColor?: string;
+  textSize?: string;
+  hoverBackgroundColor?: string;
+  hoverTextColor?: string;
+  borderColor?: string;
+}
+
+export interface StyledButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
+  $width: string;
+  $height: string;
+  $backgroundColor: string;
+  $textColor: string;
+  $textSize: string;
+  $hoverBackgroundColor: string;
+  $hoverTextColor: string;
+  $borderColor?: string;
+}

--- a/src/components/common/Button/index.ts
+++ b/src/components/common/Button/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Button';


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용
<img width="443" alt="image" src="https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/78135416/362eefd4-775d-4c91-acb2-4150619a0828">

- 프로젝트 내에서 범용적으로 사용될 사각형 버튼 컴포넌트를 구현했습니다.
- width, height는 string으로 받기 때문에 다양한 단위 커스텀이 가능합니다.
- 이 외에도 background-color, text-color, hover관련 color 등 다양한 props가 존재하고, 확장된 props를 이용해 커스텀 가능합니다.
- 위 예시 사진에서 2번째 버튼이 커스텀 없는 default 버튼 형태입니다.

# 📷스크린샷(필요 시)

![Feb-16-2024 02-25-04](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/78135416/442a4b0d-c18e-48a1-9def-832d459c8794)

> 예시 코드
```jsx
      <Button
        width="40rem"
        height="4rem"
        backgroundColor={theme.background_color}
        textColor={theme.symbol_color}
        borderColor={theme.symbol_color}
        hoverBackgroundColor={theme.symbol_color}
        hoverTextColor={theme.background_color}
        textSize="1.6rem"
        onClick={handleClick}
      >
        + 새 질문 추가하기
      </Button>
```

- 버튼을 커스텀할 수 있습니다.

![Feb-16-2024 02-25-35](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/78135416/c67a673c-bc83-4a58-9bb3-f66f7b3b2018)

- 모바일 환경일 경우 글씨 크기를 -0.3rem 자동 보정해주었습니다.
- 클릭 시 파란 박스가 나타나는 현상을 제거하고 `hoverBackgroundColor` 색상을 넣었습니다.

### 사용 시 주의할 점
버튼의 **비활성화/활성화** 기능을 사용하시려면 `isActive`, `disabled` 속성을 **동시에 사용해야 UI에 어색함이 없습니다.**

![Feb-16-2024 02-24-44](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/78135416/4e05e7ee-6c6f-4a93-82f4-e076737ee9cc)

> 예시 코드
```jsx
const [isActive, setIsActive] = useState(false);
...
<Button
    disabled={!isActive} //버튼의 비활성화/활성화 조건이 될 boolean 값을 넣습니다.
    isActive={isActive} //disabled와 반대되는 boolean 값을 넣습니다.
>
```

- 버튼이 `비활성화` 상태인 경우 **버튼의 모든 상호작용이 동작하지 않습니다.**
- 버튼이 `비활성화` 상태인 경우 background-color가 border-color가 되며, text-color가 background-color가 됩니다.
- 버튼이 `활성화` 상태로 바뀌면 정상적으로 버튼이 동작합니다.
- **위 속성 2개는 버튼을 늘 활성화 상태로 사용할 예정이라면 사용하지 않아도 됩니다!!**


> 예시 코드 전체
```jsx
      const [isActive, setIsActive] = useState(false);
      const theme = useTheme();
      ...
      <Button
        disabled={!isActive}
        isActive={isActive}
      >
        로그인
      </Button>

      <Button onClick={() => setIsActive(!isActive)}>Button Active</Button>

      <Button
        width="40rem"
        height="4rem"
        backgroundColor={theme.background_color}
        textColor={theme.symbol_color}
        borderColor={theme.symbol_color}
        hoverBackgroundColor={theme.symbol_color}
        hoverTextColor={theme.background_color}
        textSize="1.6rem"
      >
        + 새 질문 추가하기
      </Button>
```

# ✨PR Point
- 피그마 설계했던 걸 보니까 보통 글씨 크기가 모바일 환경에서는 0.3rem씩 줄어들더라구요. 그래서 일단은 임의로 모바일 환경일 경우 textSize - 0.3rem으로 자동 보정을 시켰는데 이 방식 괜찮을까요?
- 파란 박스 생기는 현상이 여기 말고도 계속 출몰(?)할 것 같은데 그냥 전역 스타일에서 `-webkit-tap-highlight-color: transparent;` 적용시키는거 어떻게 생각하시나요?
- 기타 다양한 피드백 환영합니다!!!!!