### PR TITLE
[#39] Button(원형) 컴포넌트 구현 v1.0.0

### DIFF
--- a/src/components/common/CircleButton/CircleButton.style.ts
+++ b/src/components/common/CircleButton/CircleButton.style.ts
@@ -3,7 +3,7 @@ import { css } from 'styled-components';
 
 import type { StyledCircleButtonProps } from './CircleButton.type';
 
-export const ContainerCircle = styled.button<StyledCircleButtonProps>`
+const buttonStyles = css<StyledCircleButtonProps>`
   flex-shrink: 0;
   display: flex;
   justify-content: center;
@@ -48,7 +48,13 @@ export const ContainerCircle = styled.button<StyledCircleButtonProps>`
   -webkit-tap-highlight-color: transparent;
 `;
 
-export const Circle = styled(ContainerCircle)`
+export const ContainerCircle = styled.button`
+  ${buttonStyles}
+`;
+
+export const Circle = styled.div<StyledCircleButtonProps>`
+  ${buttonStyles}
+
   background-color: ${({ theme }) => theme.symbol_color};
   width: calc(${(props) => props.$size} * 0.85);
   height: calc(${(props) => props.$size} * 0.85);

--- a/src/components/common/CircleButton/CircleButton.style.ts
+++ b/src/components/common/CircleButton/CircleButton.style.ts
@@ -1,0 +1,65 @@
+import { styled } from 'styled-components';
+import { css } from 'styled-components';
+
+import type { StyledCircleButtonProps } from './CircleButton.type';
+
+export const ContainerCircle = styled.button<StyledCircleButtonProps>`
+  flex-shrink: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  ${(props) => {
+    if (!props.$isBackgroundWhite) {
+      return css`
+        background-color: ${({ theme }) => theme.symbol_color}40;
+      `;
+    } else {
+      return css`
+        background-color: rgba(255, 255, 255, 0.4);
+      `;
+    }
+  }};
+  color: ${({ theme }) => theme.background_color};
+  font-size: calc(${(props) => props.$size} / 2);
+
+  width: ${(props) => props.$size};
+  height: ${(props) => props.$size};
+  border-radius: 50%;
+
+  transition: all 0.2s ease;
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      background-color: ${({ theme }) => theme.symbol_secondary_color}40;
+      color: ${({ theme }) => theme.secondary_color};
+    }
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+  }
+
+  &:active {
+    background-color: ${({ theme }) => theme.symbol_secondary_color}40;
+    color: ${({ theme }) => theme.secondary_color};
+  }
+
+  -webkit-tap-highlight-color: transparent;
+`;
+
+export const Circle = styled(ContainerCircle)`
+  background-color: ${({ theme }) => theme.symbol_color};
+  width: calc(${(props) => props.$size} * 0.85);
+  height: calc(${(props) => props.$size} * 0.85);
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      background-color: ${({ theme }) => theme.symbol_secondary_color};
+    }
+  }
+
+  &:active {
+    background-color: ${({ theme }) => theme.symbol_secondary_color};
+  }
+`;

--- a/src/components/common/CircleButton/CircleButton.tsx
+++ b/src/components/common/CircleButton/CircleButton.tsx
@@ -1,8 +1,14 @@
 import { Circle, ContainerCircle } from './CircleButton.style';
 import { CircleButtonProps } from './CircleButton.type';
 
+/**
+ * @brief 질문 및 꾸러미 추가 동작을 수행하는 원형 버튼입니다.
+ * @param size px,rem,% 등 자유롭게 단위 커스텀 가능합니다.
+ * @param isBackgroundWhite 버튼 테두리 베이스를 white로 설정할 수 있는 boolean 속성입니다.
+ * 버튼이 올라갈 컴포넌트의 배경 색이 심볼 색과 같은 경우, 해당 속성을 true로 설정합니다.
+ */
 const CircleButton = ({
-  size = '10rem',
+  size = '5rem',
   isBackgroundWhite = false,
   ...props
 }: CircleButtonProps) => {

--- a/src/components/common/CircleButton/CircleButton.tsx
+++ b/src/components/common/CircleButton/CircleButton.tsx
@@ -1,0 +1,22 @@
+import { Circle, ContainerCircle } from './CircleButton.style';
+import { CircleButtonProps } from './CircleButton.type';
+
+const CircleButton = ({
+  size = '10rem',
+  isBackgroundWhite = false,
+  ...props
+}: CircleButtonProps) => {
+  return (
+    <ContainerCircle
+      $size={size}
+      $isBackgroundWhite={isBackgroundWhite}
+      {...props}
+    >
+      <Circle $size={size}>
+        <span>+</span>
+      </Circle>
+    </ContainerCircle>
+  );
+};
+
+export default CircleButton;

--- a/src/components/common/CircleButton/CircleButton.type.ts
+++ b/src/components/common/CircleButton/CircleButton.type.ts
@@ -1,0 +1,13 @@
+import { ButtonHTMLAttributes } from 'react';
+
+export interface CircleButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
+  size?: string;
+  isBackgroundWhite?: boolean;
+}
+
+export interface StyledCircleButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
+  $size?: string;
+  $isBackgroundWhite?: boolean;
+}

--- a/src/components/common/CircleButton/index.ts
+++ b/src/components/common/CircleButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CircleButton';


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용

<img width="771" alt="image" src="https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/78135416/7420ac30-6be4-4371-ad80-875511bdd0fd">

- 질문 및 질문 꾸러미 추가 동작을 수행하는 원형 버튼입니다.
- 사각형 버튼과 달리 사용되는 곳이 제한적이기 때문에 `size`, `isBackgroundWhite` 2개로 props를 대폭 줄였습니다.

# 📷스크린샷(필요 시)

### 사용 예시

<img width="362" alt="image" src="https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/78135416/20dc5e13-86be-4b37-a6a1-0fc4acd34795">

- 이렇게 버튼이 올라갈 컴포넌트의 배경 색이 버튼 색과 같은 경우, `isBackgroundWhite=true` 로 설정해야 합니다.

> 예시 코드

```jsx
      <ShadowBox isActive> // 배경이 green인 박스 컨테이너
          <span>어쩌고저쩌고질문이어쩌고</span>
          <CircleButton isBackgroundWhite /> // 배경이 버튼 내부 색상과 같은 green이므로 isBackgroundWhite=true 설정
      </ShadowBox>
```

<img width="754" alt="image" src="https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/78135416/99f0fbb6-0122-40b7-985b-bec31024c8ac">

- ShadowBox의 오른쪽에 질문 추가 버튼을 위치시키려면 다음과 같이 코드를 작성합니다.

> 예시 코드

```jsx
      <ShadowBox
        ...
        style={{ position: 'relative' }} // 부모의 position을 relative로 설정
      >
        <CircleButton
          size="6rem"
          style={{
            position: 'absolute',
            right: '-3rem', // - size/2
            top: 'calc(50% - 3rem)', // 50% - size/2 
          }}
        />
      </ShadowBox>
```

# ✨PR Point
- props는 일단 저렇게 2개만 열어뒀는데 더 열어주면 좋을만한 것들이 있을까요?
- 이 외에 개선할만한 부분 있다면 말씀해주세요!!!