### PR TITLE
[#52] Badge 컴포넌트 구현 v1.1.0

### DIFF
--- a/src/components/common/Badge/Badge.style.ts
+++ b/src/components/common/Badge/Badge.style.ts
@@ -1,8 +1,12 @@
 import styled, { css } from 'styled-components';
 
+import { FONT_SEMI_BOLD } from '@/constants';
+
 import { PropsStyledBadge } from './Badge.type';
 
 const sizeMapping = {
+  xxs: '0.8rem',
+  xs: '1rem',
   s: '1.4rem',
   m: '1.8rem',
   l: '2.2rem',
@@ -21,6 +25,11 @@ const stateStyles = {
     background-color: white;
     color: ${({ theme }) => theme.gray_300};
   `,
+  hot: css`
+    font-weight: ${FONT_SEMI_BOLD};
+    background-color: #f7cece;
+    color: #f84c4c;
+  `,
 };
 
 export const StyledBadge = styled.span<PropsStyledBadge>`
@@ -28,6 +37,7 @@ export const StyledBadge = styled.span<PropsStyledBadge>`
   border-radius: 3rem;
   padding: 0.75rem 1.25rem;
   width: fit-content;
+  margin: ${({ $margin }) => $margin};
   cursor: pointer;
   transition: background-color 0.5s ease;
   font-size: ${({ $size }) =>
@@ -41,5 +51,10 @@ export const StyledBadge = styled.span<PropsStyledBadge>`
     &:hover {
       ${({ $isHover }) => $isHover && stateStyles.focus}
     }
+  }
+  @media screen and (max-width: 280px) {
+    padding: 0.75rem 1.25rem;
+    width: fit-content;
+    font-size: 1rem;
   }
 `;

--- a/src/components/common/Badge/Badge.style.ts
+++ b/src/components/common/Badge/Badge.style.ts
@@ -27,8 +27,8 @@ const stateStyles = {
   `,
   hot: css`
     font-weight: ${FONT_SEMI_BOLD};
-    background-color: #f7cece;
-    color: #f84c4c;
+    background-color: ${({ theme }) => theme.hotBadge_background_color};
+    color: ${({ theme }) => theme.hotBadge_color};
   `,
 };
 

--- a/src/components/common/Badge/Badge.tsx
+++ b/src/components/common/Badge/Badge.tsx
@@ -5,12 +5,14 @@ import { PropsBadge } from './Badge.type';
  * @summary 사용법 <Badge
       $size={'m'}
       $state="basic"
+      $margin="10px 0px 3px 10px"
       $isHover={true}
       $text={'백엔드'}
     />
  * @description 공통 Badge 컴포넌트
  * @param $size font-size의 크기
- * @param $state basic, focus, hashTag가 있으면 background-color와 color의 색깔을 지정합니다.
+ * @param $state basic, focus, hashTag, hot이 있으면 background-color와 color의 색깔을 지정합니다.
+ * @param $margin margin 값을 받습니다.
  * @param $hover true false에 따라 hover가 적용됩니다.
  * @param $text 뱃지안에 들어간 text값 입니다.
  * @returns

--- a/src/components/common/Badge/Badge.tsx
+++ b/src/components/common/Badge/Badge.tsx
@@ -16,12 +16,20 @@ import { PropsBadge } from './Badge.type';
  * @returns
  */
 
-const Badge = ({ $state, $isHover, $size, $text, ...props }: PropsBadge) => {
+const Badge = ({
+  $state,
+  $isHover,
+  $size,
+  $text,
+  $margin,
+  ...props
+}: PropsBadge) => {
   return (
     <StyledBadge
       $size={$size}
       $state={$state}
       $isHover={$isHover}
+      $margin={$margin}
       {...props}
     >
       {$state === 'hashTag' ? `#${$text}` : $text}

--- a/src/components/common/Badge/Badge.type.ts
+++ b/src/components/common/Badge/Badge.type.ts
@@ -1,8 +1,9 @@
 export interface PropsBadge extends React.HTMLAttributes<HTMLSpanElement> {
-  $state: 'basic' | 'focus' | 'hashTag';
-  $size: 's' | 'm' | 'l' | number;
+  $state: 'basic' | 'focus' | 'hashTag' | 'hot';
+  $size: 'xxs' | 'xs' | 's' | 'm' | 'l' | number;
   $text: string;
   $isHover?: boolean;
+  $margin?: string;
 }
 
 export type PropsStyledBadge = Omit<PropsBadge, '$text'>;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -8,6 +8,9 @@ export const lightTheme: object = {
   primary_color: '#0F1118',
   secondary_color: '#e6e6e9',
 
+  hotBadge_background_color: ' #f7cece',
+  hotBadge_color: '#f84c4c',
+
   gray_600: '#565656',
   gray_500: '#5E5E5E',
   gray_400: '#909090',
@@ -27,6 +30,9 @@ export const darkTheme: object = {
 
   primary_color: '#e6e6e9',
   secondary_color: '#0F1118',
+
+  hotBadge_background_color: ' #f7cece',
+  hotBadge_color: '#f84c4c',
 
   // 사용성 조사 필요, PR시에 명시해주기 혹은 사전에 논의해주기
   gray_600: '#565656',


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용
기존의 Badge 컴포넌트를 확장하였습니다.
# 📷스크린샷(필요 시)
<img width="423" alt="스크린샷 2024-02-17 오후 5 18 20" src="https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/81172451/da820833-bfee-4627-8c55-b6183a6f2870">

# ✨PR Point
위 사진 코드
```js
 <Badge
        $margin="10px 0px 3px 10px"
        $size={'xxs'}
        $state="basic"
        $text="프론트엔드"
      />
      <Badge
        $size={'xs'}
        $state="basic"
        $text="프론트엔드"
      />
      <Badge
        $size={'s'}
        $state="basic"
        $text="프론트엔드"
      />
      <Badge
        $size={'m'}
        $state="basic"
        $text="프론트엔드"
      />
      <Badge
        $size={'m'}
        $state="hot"
        $text="HOT"
      />
```

- 갤럭시 폴드 UI에 필요한 xss, xs 사이즈를 만들었습니다.
- Tagfilter에서 margin값이 쓰이므로 `margin`을 받는 props를 추가하였습니다.
- 이제 뱃지 컴포넌트가 fix 되어있기에 HOT 태그도 필요하여 추가하였습니다.