### PR TITLE
[#30] Textarea 컴포넌트 구현 v1.0.0

### DIFF
--- a/src/components/common/Textarea/Textarea.style.ts
+++ b/src/components/common/Textarea/Textarea.style.ts
@@ -1,0 +1,43 @@
+import styled from 'styled-components';
+
+import { Col } from '@/styles/globalStyles';
+
+import { TextareaStyledProps } from './Textarea.type';
+
+export const TextareaWrapper = styled(Col)<TextareaStyledProps>`
+  width: ${(props) => props.$width};
+  font-size: ${(props) => (props.$fontSize ? props.$fontSize : 2)}rem;
+`;
+
+export const Label = styled.label<TextareaStyledProps>`
+  color: ${({ theme }) => theme.primary_color};
+  margin-bottom: ${(props) => (props.$margin ? props.$margin : 1.5)}rem;
+`;
+
+export const StyledTextarea = styled.textarea<TextareaStyledProps>`
+  height: ${(props) => props.$height};
+  color: ${({ theme }) => theme.primary_color};
+  background-color: transparent;
+  padding: 1rem;
+  box-sizing: border-box;
+  border: none;
+  border: 0.15rem solid ${({ theme }) => theme.gray_100};
+  border-radius: 0.5rem;
+  outline: none;
+  transition: border 0.2s;
+  resize: none;
+
+  &:focus {
+    border: 0.15rem solid ${({ theme }) => theme.symbol_secondary_color};
+  }
+
+  &::placeholder {
+    color: ${({ theme }) => theme.gray_300};
+  }
+`;
+
+export const ErrorMessage = styled.div<TextareaStyledProps>`
+  color: ${({ theme }) => theme.error_red};
+  margin-top: ${(props) => (props.$margin ? props.$margin + 0.15 : 1.65)}rem;
+  visibility: ${(props) => (props.$isError ? 'hidden' : undefined)};
+`;

--- a/src/components/common/Textarea/Textarea.style.ts
+++ b/src/components/common/Textarea/Textarea.style.ts
@@ -32,6 +32,8 @@ export const StyledTextarea = styled.textarea<TextareaStyledProps>`
   transition: border 0.2s;
   resize: none;
 
+  line-height: ${(props) => (props.$fontSize ? props.$fontSize + 0.6 : 2.2)}rem;
+
   &:focus {
     border: 0.15rem solid ${({ theme }) => theme.symbol_secondary_color};
   }

--- a/src/components/common/Textarea/Textarea.style.ts
+++ b/src/components/common/Textarea/Textarea.style.ts
@@ -7,7 +7,7 @@ import { TextareaStyledProps } from './Textarea.type';
 export const TextareaWrapper = styled(Col)<TextareaStyledProps>`
   /* TODO: 768 => constans > MOBILE로 수정하기 */
   @media screen and (max-width: 768px) {
-    font-size: ${(props) => (props.$fontSize ? props.$fontSize - 0.3 : 1.3)}rem;
+    font-size: ${(props) => (props.$fontSize ? props.$fontSize - 0.2 : 1.4)}rem;
   }
 
   width: ${(props) => props.$width};
@@ -42,7 +42,7 @@ export const StyledTextarea = styled.textarea<TextareaStyledProps>`
 `;
 
 export const ErrorMessage = styled.div<TextareaStyledProps>`
-  font-size: ${(props) => (props.$fontSize ? props.$fontSize - 0.6 : 1)}rem;
+  font-size: ${(props) => (props.$fontSize ? props.$fontSize - 0.3 : 1.3)}rem;
   color: ${({ theme }) => theme.error_red};
   margin-top: ${(props) => (props.$margin ? props.$margin + 0.15 : 1.65)}rem;
   visibility: ${({ $isError }) => ($isError ? 'hidden' : undefined)};

--- a/src/components/common/Textarea/Textarea.style.ts
+++ b/src/components/common/Textarea/Textarea.style.ts
@@ -5,8 +5,13 @@ import { Col } from '@/styles/globalStyles';
 import { TextareaStyledProps } from './Textarea.type';
 
 export const TextareaWrapper = styled(Col)<TextareaStyledProps>`
+  /* TODO: 768 => constans > MOBILE로 수정하기 */
+  @media screen and (max-width: 768px) {
+    font-size: ${(props) => (props.$fontSize ? props.$fontSize - 0.3 : 1.3)}rem;
+  }
+
   width: ${(props) => props.$width};
-  font-size: ${(props) => (props.$fontSize ? props.$fontSize : 2)}rem;
+  font-size: ${(props) => (props.$fontSize ? props.$fontSize : 1.6)}rem;
 `;
 
 export const Label = styled.label<TextareaStyledProps>`
@@ -37,7 +42,9 @@ export const StyledTextarea = styled.textarea<TextareaStyledProps>`
 `;
 
 export const ErrorMessage = styled.div<TextareaStyledProps>`
+  font-size: ${(props) => (props.$fontSize ? props.$fontSize - 0.6 : 1)}rem;
   color: ${({ theme }) => theme.error_red};
   margin-top: ${(props) => (props.$margin ? props.$margin + 0.15 : 1.65)}rem;
-  visibility: ${(props) => (props.$isError ? 'hidden' : undefined)};
+  visibility: ${({ $isError }) => ($isError ? 'hidden' : undefined)};
+  cursor: default;
 `;

--- a/src/components/common/Textarea/Textarea.tsx
+++ b/src/components/common/Textarea/Textarea.tsx
@@ -1,5 +1,64 @@
-const Textarea = () => {
-  return <div></div>;
+import {
+  ErrorMessage,
+  Label,
+  StyledTextarea,
+  TextareaWrapper,
+} from './Textarea.style';
+import { TextareaProps } from './Textarea.type';
+
+/**
+ *
+ * @description 공통 Textarea 컴포넌트
+ * @summary 사용법 :
+ * <Textarea
+        width={'50rem'}
+        height={'50rem'}
+        fontSize={2}
+        margin={1.5}
+        label={'라벨이다'}
+        placeholder={'닉네임 써라'}
+        errorMessage={'에러다'}
+      />
+ * @param width : 필수 | string 타입. textarea의 너비를 의미함. (px or rem or % 로 기입)
+ * @param height : 필수 | string 타입. textarea의  높이를 의미함. (px or rem or % 로 기입)
+ * @param fontSize : 선택 | number 타입. 라벨, textarea, 에러 메시지의 폰트 사이즈를 의미. 생략 시 기본 값으로 2가 설정. (단위는 rem)
+ * @param margin : 선택 | number 타입. 라벨, textarea, 에러 메시지 간 간격을 의미. 생략 시 기본 값으로 1.5가 설정. (단위는 rem)
+ * @param label : 선택 | string 타입. textarea 위에 붙는 라벨 역할.
+ * @param placeholder : 선택 | string 타입. textarea의 placeholder 역할.
+ * @param errorMessage : 선택 | string 타입. textarea의 에러 메시지 역할.
+ * @param ...props : 커스텀을 위함 (+ react-hook-form)
+ * @returns
+ */
+
+const Textarea = ({
+  width,
+  height,
+  fontSize,
+  margin,
+  label,
+  placeholder,
+  errorMessage,
+  ...props
+}: TextareaProps) => {
+  return (
+    <TextareaWrapper
+      $width={width}
+      $fontSize={fontSize}
+    >
+      <Label $margin={margin}>{label}</Label>
+      <StyledTextarea
+        $height={height}
+        placeholder={placeholder}
+        {...props}
+      />
+      <ErrorMessage
+        $isError={errorMessage?.length === 0}
+        $margin={margin}
+      >
+        {errorMessage?.length === 0 ? 'no Error' : errorMessage}
+      </ErrorMessage>
+    </TextareaWrapper>
+  );
 };
 
 export default Textarea;

--- a/src/components/common/Textarea/Textarea.tsx
+++ b/src/components/common/Textarea/Textarea.tsx
@@ -52,6 +52,7 @@ const Textarea = ({
         {...props}
       />
       <ErrorMessage
+        $fontSize={fontSize}
         $isError={errorMessage?.length === 0}
         $margin={margin}
       >

--- a/src/components/common/Textarea/Textarea.tsx
+++ b/src/components/common/Textarea/Textarea.tsx
@@ -1,0 +1,5 @@
+const Textarea = () => {
+  return <div></div>;
+};
+
+export default Textarea;

--- a/src/components/common/Textarea/Textarea.tsx
+++ b/src/components/common/Textarea/Textarea.tsx
@@ -45,7 +45,7 @@ const Textarea = ({
       $width={width}
       $fontSize={fontSize}
     >
-      <Label $margin={margin}>{label}</Label>
+      {label && <Label $margin={margin}>{label}</Label>}
       <StyledTextarea
         $height={height}
         placeholder={placeholder}

--- a/src/components/common/Textarea/Textarea.tsx
+++ b/src/components/common/Textarea/Textarea.tsx
@@ -48,6 +48,7 @@ const Textarea = ({
       {label && <Label $margin={margin}>{label}</Label>}
       <StyledTextarea
         $height={height}
+        $fontSize={fontSize}
         placeholder={placeholder}
         {...props}
       />

--- a/src/components/common/Textarea/Textarea.type.ts
+++ b/src/components/common/Textarea/Textarea.type.ts
@@ -1,0 +1,18 @@
+export interface TextareaProps
+  extends React.HTMLAttributes<HTMLTextAreaElement> {
+  width: string;
+  height: string;
+  fontSize?: number;
+  margin?: number;
+  label?: string;
+  placeholder?: string;
+  errorMessage?: string;
+}
+
+export interface TextareaStyledProps {
+  $width?: string;
+  $height?: string;
+  $fontSize?: number;
+  $margin?: number;
+  $isError?: boolean;
+}

--- a/src/components/common/Textarea/index.ts
+++ b/src/components/common/Textarea/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Textarea';


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용

공통 컴포넌트인 Textarea 컴포넌트를 구현했습니다.

# 📷스크린샷(필요 시)

- dev 브랜치 내용이 pull 되지 않아서 테마 적용을 못했습니다 ㅠㅠ Input 컴포넌트와 다른 부분은 `input이냐 textarea이냐` 차이 일 뿐이라 [Input 컴포넌트](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/pull/45) 스크린샷과 큰 차이는 없습니다 !

# 사용 방법

```typescript

      <Textarea
        width={'50rem'}
        height={'50rem'}
        fontSize={2}
        margin={1.5}
        label={'라벨이다'}
        placeholder={'닉네임 써라'}
        errorMessage={'에러다'}
      />

```

- `Textarea` 컴포넌트에서 필수 props는 `width`, `height`입니다.
  - `width`는 string 타입이며, px, rem, %를 다 받을수 있도록 구현했습니다.
  - `height`는 string 타입이며, px, rem, %를 다 받을수 있도록 구현했습니다.

- `Textarea` 컴포넌트에서 선택 props는 `fontSize`, `margin`, `label`, `placeholder`, `errorMessage` 입니다.
  - `fontSize`는 number 타입이며, 라벨, input, 에러 메시지의 폰트 사이즈를 의미합니다. 생략 시 기본 값으로 `2`가 설정됩니다. (단위는 rem)
  - `margin`은 number 타입이며, 라벨, textarea, 에러 메시지 간 간격을 의미합니다. 생략 시 기본 값으로 `1.5`가 설정 됩니다. (단위는 rem)
  - `label`은 string 타입이며, textarea 위에 붙는 라벨 역할을 합니다.
  - `placrholder`는 string 타입이며, textarea의 placeholder 역할을 합니다.
  - `errorMessage`는 string 타입이며, textarea 하단 에러 메시지 역할을 합니다.

# ✨PR Point

Input 컴포넌트와 내용이 매우 흡사하여 Input과 Textarea 컴포넌트를 하나로 통일하면 좋을 것 같은데 **통합된 컴포넌트 명은 어떻게 하면 좋을까요??**