### PR TITLE
[#58] Input 컴포넌트 v1.0.1

### DIFF
--- a/src/components/common/Input/Input.style.ts
+++ b/src/components/common/Input/Input.style.ts
@@ -1,10 +1,15 @@
 import styled from 'styled-components';
 
+import { MOBILE } from '@/constants';
 import { Col } from '@/styles/globalStyles';
 
 import { InputStyledProps } from './Input.type';
 
 export const InputWrapper = styled(Col)<InputStyledProps>`
+  @media screen and (max-width: ${MOBILE}px) {
+    font-size: ${(props) => (props.$fontSize ? props.$fontSize - 0.3 : 1.3)}rem;
+  }
+
   width: ${(props) => props.$width};
   font-size: ${(props) => (props.$fontSize ? props.$fontSize : 1.6)}rem;
 `;
@@ -38,4 +43,5 @@ export const ErrorMessage = styled.div<InputStyledProps>`
   color: ${({ theme }) => theme.error_red};
   margin-top: ${(props) => (props.$margin ? props.$margin + 0.15 : 1.65)}rem;
   visibility: ${({ $isError }) => ($isError ? 'hidden' : undefined)};
+  cursor: default;
 `;

--- a/src/components/common/Input/Input.style.ts
+++ b/src/components/common/Input/Input.style.ts
@@ -39,7 +39,7 @@ export const StyledInput = styled.input`
 `;
 
 export const ErrorMessage = styled.div<InputStyledProps>`
-  font-size: ${(props) => (props.$fontSize ? props.$fontSize - 0.6 : 1)}rem;
+  font-size: ${(props) => (props.$fontSize ? props.$fontSize - 0.3 : 1.3)}rem;
   color: ${({ theme }) => theme.error_red};
   margin-top: ${(props) => (props.$margin ? props.$margin + 0.15 : 1.65)}rem;
   visibility: ${({ $isError }) => ($isError ? 'hidden' : undefined)};

--- a/src/components/common/Input/Input.style.ts
+++ b/src/components/common/Input/Input.style.ts
@@ -7,7 +7,7 @@ import { InputStyledProps } from './Input.type';
 
 export const InputWrapper = styled(Col)<InputStyledProps>`
   @media screen and (max-width: ${MOBILE}px) {
-    font-size: ${(props) => (props.$fontSize ? props.$fontSize - 0.3 : 1.3)}rem;
+    font-size: ${(props) => (props.$fontSize ? props.$fontSize - 0.2 : 1.4)}rem;
   }
 
   width: ${(props) => props.$width};

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -38,7 +38,7 @@ const Input = ({
       $width={width}
       $fontSize={fontSize}
     >
-      <Label $margin={margin}>{label}</Label>
+      {label && <Label $margin={margin}>{label}</Label>}
       <StyledInput
         placeholder={placeholder}
         {...props}


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용

- 모바일 환경일 때 Input 컴포넌트의 라벨과 input의 폰트 사이즈를 -0.2rem 보정했습니다.
- label props를 넘겨주지 않았을 때 <label> 태그가 남아있는 문제를 해결했습니다.
 
# 📷스크린샷(필요 시)

https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/fbc28427-2051-408c-b54e-530f65dafc94

위 스크린샷은 화면 너비가 줄어들 때 font-size가 바뀌는 것을 녹화한 것입니다.

# ✨PR Point

- 에러 메시지는 너무 작아져서 따로 보정하진 않았습니다. 에러 메시지도 보정 해줘야 할까요 ?
