### PR TITLE
[#57] 검색바 컴포넌트 구현 v1.0.0

### DIFF
--- a/src/components/common/SearchBar/SearchBar.style.ts
+++ b/src/components/common/SearchBar/SearchBar.style.ts
@@ -10,6 +10,7 @@ export const SearchBarWrapper = styled.div`
   position: relative;
   width: 80%;
   max-width: 432px;
+  min-width: 224px;
 
   & > :nth-child(2) {
     position: absolute;

--- a/src/components/common/SearchBar/SearchBar.style.ts
+++ b/src/components/common/SearchBar/SearchBar.style.ts
@@ -14,7 +14,7 @@ export const SearchBarWrapper = styled.div`
 
   & > :nth-child(2) {
     position: absolute;
-    top: 0;
+    top: -0.8rem;
     right: 0;
     color: ${({ theme }) => theme.primary_color};
   }

--- a/src/components/common/SearchBar/SearchBar.style.ts
+++ b/src/components/common/SearchBar/SearchBar.style.ts
@@ -11,7 +11,8 @@ export const SearchBarWrapper = styled.div<SearchBarStyleProps>`
 
   position: relative;
   width: 80%;
-  max-width: ${(props) => (props.$maxWidth ? props.$maxWidth : '432px')};
+  max-width: ${(props) =>
+    props.$maxWidth ? props.$maxWidth : `calc(${MOBILE}px * 0.8)`};
   min-width: 224px;
 
   & > :nth-child(2) {

--- a/src/components/common/SearchBar/SearchBar.style.ts
+++ b/src/components/common/SearchBar/SearchBar.style.ts
@@ -17,7 +17,7 @@ export const SearchBarWrapper = styled.div<SearchBarStyleProps>`
 
   & > :nth-child(2) {
     position: absolute;
-    top: -0.8rem;
+    top: 0;
     right: 0;
     color: ${({ theme }) => theme.primary_color};
   }

--- a/src/components/common/SearchBar/SearchBar.style.ts
+++ b/src/components/common/SearchBar/SearchBar.style.ts
@@ -17,4 +17,6 @@ export const SearchBarWrapper = styled.div`
     top: 0;
     right: 0;
   }
+
+  -webkit-tap-highlight-color: transparent;
 `;

--- a/src/components/common/SearchBar/SearchBar.style.ts
+++ b/src/components/common/SearchBar/SearchBar.style.ts
@@ -18,6 +18,4 @@ export const SearchBarWrapper = styled.div`
     right: 0;
     color: ${({ theme }) => theme.primary_color};
   }
-
-  -webkit-tap-highlight-color: transparent;
 `;

--- a/src/components/common/SearchBar/SearchBar.style.ts
+++ b/src/components/common/SearchBar/SearchBar.style.ts
@@ -6,13 +6,13 @@ import { SearchBarStyleProps } from './SearchBar.type';
 
 export const SearchBarWrapper = styled.div<SearchBarStyleProps>`
   @media screen and (max-width: ${MOBILE}px) {
-    width: 80%;
     margin: 0 auto;
-    min-width: 224px;
   }
 
   position: relative;
-  width: ${(props) => (props.$width ? props.$width : '432px')};
+  width: 80%;
+  max-width: ${(props) => (props.$maxWidth ? props.$maxWidth : '432px')};
+  min-width: 224px;
 
   & > :nth-child(2) {
     position: absolute;

--- a/src/components/common/SearchBar/SearchBar.style.ts
+++ b/src/components/common/SearchBar/SearchBar.style.ts
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+
+import { MOBILE } from '@/constants';
+
+export const SearchBarWrapper = styled.div`
+  @media screen and (max-width: ${MOBILE}px) {
+    margin: 0 auto;
+  }
+
+  position: relative;
+  width: 80%;
+  max-width: 432px;
+
+  & > :nth-child(2) {
+    position: absolute;
+    top: 0;
+    right: 0;
+  }
+`;

--- a/src/components/common/SearchBar/SearchBar.style.ts
+++ b/src/components/common/SearchBar/SearchBar.style.ts
@@ -2,15 +2,17 @@ import styled from 'styled-components';
 
 import { MOBILE } from '@/constants';
 
-export const SearchBarWrapper = styled.div`
+import { SearchBarStyleProps } from './SearchBar.type';
+
+export const SearchBarWrapper = styled.div<SearchBarStyleProps>`
   @media screen and (max-width: ${MOBILE}px) {
+    width: 80%;
     margin: 0 auto;
+    min-width: 224px;
   }
 
   position: relative;
-  width: 80%;
-  max-width: 432px;
-  min-width: 224px;
+  width: ${(props) => (props.$width ? props.$width : '432px')};
 
   & > :nth-child(2) {
     position: absolute;

--- a/src/components/common/SearchBar/SearchBar.style.ts
+++ b/src/components/common/SearchBar/SearchBar.style.ts
@@ -16,6 +16,7 @@ export const SearchBarWrapper = styled.div`
     position: absolute;
     top: 0;
     right: 0;
+    color: ${({ theme }) => theme.primary_color};
   }
 
   -webkit-tap-highlight-color: transparent;

--- a/src/components/common/SearchBar/SearchBar.tsx
+++ b/src/components/common/SearchBar/SearchBar.tsx
@@ -1,5 +1,34 @@
-const SearchBar = () => {
-  return <div>검색바 컴포넌트</div>;
+import { MdSearch } from 'react-icons/md';
+
+import IconWrapper from '../IconWrapper';
+import Input from '../Input';
+import { SearchBarWrapper } from './SearchBar.style';
+import { SearchBarProps } from './SearchBar.type';
+
+const SearchBar = ({
+  handleSearchIcon,
+  handleSubmit,
+  ...props
+}: SearchBarProps) => {
+  return (
+    <SearchBarWrapper>
+      <form onSubmit={handleSubmit}>
+        <Input
+          width={'100%'}
+          margin={0}
+          placeholder={'검색어를 입력해주세요.'}
+          style={{ paddingRight: '3rem' }}
+          {...props}
+        />
+      </form>
+      <IconWrapper
+        $size={'xs'}
+        onClick={handleSearchIcon}
+      >
+        <MdSearch />
+      </IconWrapper>
+    </SearchBarWrapper>
+  );
 };
 
 export default SearchBar;

--- a/src/components/common/SearchBar/SearchBar.tsx
+++ b/src/components/common/SearchBar/SearchBar.tsx
@@ -17,7 +17,7 @@ import { SearchBarProps } from './SearchBar.type';
 
  * @param handleSearchIcon : 선택 | 함수. 검색 아이콘에 들어갈 클릭 이벤트를 받음.
  * @param handleFormSubmit : 선택 | 함수. input에 검색어를 입력 후 엔터 할 때 submit 이벤트를 받음 (react-hook-form의 handleSubmit 함수와 연관됨.)
- * @param width : 선택 | 문자열 타입. 검색바 컴포넌트의 너비를 의미함. (px, rem, %를 다 받습니다.)
+ * @param maxWidth : 선택 | 문자열 타입. 검색바 컴포넌트의 최대 너비를 의미함. (px, rem, %를 다 받습니다.)
  * @param …props : 커스텀을 위함 (+ react-hook-form)
  * @returns
  */
@@ -25,11 +25,11 @@ import { SearchBarProps } from './SearchBar.type';
 const SearchBar = ({
   handleSearchIcon,
   handleFormSubmit,
-  width,
+  maxWidth,
   ...props
 }: SearchBarProps) => {
   return (
-    <SearchBarWrapper $width={width}>
+    <SearchBarWrapper $maxWidth={maxWidth}>
       <form onSubmit={handleFormSubmit}>
         <Input
           width={'100%'}

--- a/src/components/common/SearchBar/SearchBar.tsx
+++ b/src/components/common/SearchBar/SearchBar.tsx
@@ -41,10 +41,11 @@ export default TestPage;
 const SearchBar = ({
   handleSearchIcon,
   handleSubmit,
+  width,
   ...props
 }: SearchBarProps) => {
   return (
-    <SearchBarWrapper>
+    <SearchBarWrapper $width={width}>
       <form onSubmit={handleSubmit}>
         <Input
           width={'100%'}

--- a/src/components/common/SearchBar/SearchBar.tsx
+++ b/src/components/common/SearchBar/SearchBar.tsx
@@ -5,6 +5,39 @@ import Input from '../Input';
 import { SearchBarWrapper } from './SearchBar.style';
 import { SearchBarProps } from './SearchBar.type';
 
+/**
+ *
+ * @description SearchBar 컴포넌트
+ * @summary 사용법 :
+ * import { useForm } from 'react-hook-form';
+
+import SearchBar from '@/components/common/SearchBar';
+
+const TestPage = () => {
+  const { handleSubmit } = useForm();
+
+  const onSubmit = () => {
+    alert('sumbit!');
+  };
+
+  return (
+    <>
+      <SearchBar
+        handleSearchIcon={() => alert('검색됨!')}
+        handleSubmit={handleSubmit(onSubmit)}
+      />
+    </>
+  );
+};
+
+export default TestPage;
+
+ * @param handleSearchIcon : 선택 | 함수. 검색 아이콘에 들어갈 클릭 이벤트를 받음.
+ * @param handleSubmit : 선택 | 함수. input에 검색어를 입력 후 엔터 할 때 submit 이벤트를 받음
+ * @param ...props : 커스텀을 위함 (+ react-hook-form)
+ * @returns
+ */
+
 const SearchBar = ({
   handleSearchIcon,
   handleSubmit,

--- a/src/components/common/SearchBar/SearchBar.tsx
+++ b/src/components/common/SearchBar/SearchBar.tsx
@@ -9,32 +9,16 @@ import { SearchBarProps } from './SearchBar.type';
  *
  * @description SearchBar 컴포넌트
  * @summary 사용법 :
- * import { useForm } from 'react-hook-form';
-
-import SearchBar from '@/components/common/SearchBar';
-
-const TestPage = () => {
-  const { handleSubmit } = useForm();
-
-  const onSubmit = () => {
-    alert('sumbit!');
-  };
-
-  return (
-    <>
       <SearchBar
         handleSearchIcon={() => alert('검색됨!')}
-        handleSubmit={handleSubmit(onSubmit)}
+        handleFormSubmit={handleSubmit(onSubmit)}
+        width={'500px'}
       />
-    </>
-  );
-};
-
-export default TestPage;
 
  * @param handleSearchIcon : 선택 | 함수. 검색 아이콘에 들어갈 클릭 이벤트를 받음.
- * @param handleSubmit : 선택 | 함수. input에 검색어를 입력 후 엔터 할 때 submit 이벤트를 받음
- * @param ...props : 커스텀을 위함 (+ react-hook-form)
+ * @param handleFormSubmit : 선택 | 함수. input에 검색어를 입력 후 엔터 할 때 submit 이벤트를 받음 (react-hook-form의 handleSubmit 함수와 연관됨.)
+ * @param width : 선택 | 문자열 타입. 검색바 컴포넌트의 너비를 의미함. (px, rem, %를 다 받습니다.)
+ * @param …props : 커스텀을 위함 (+ react-hook-form)
  * @returns
  */
 

--- a/src/components/common/SearchBar/SearchBar.tsx
+++ b/src/components/common/SearchBar/SearchBar.tsx
@@ -40,13 +40,13 @@ export default TestPage;
 
 const SearchBar = ({
   handleSearchIcon,
-  handleSubmit,
+  handleFormSubmit,
   width,
   ...props
 }: SearchBarProps) => {
   return (
     <SearchBarWrapper $width={width}>
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={handleFormSubmit}>
         <Input
           width={'100%'}
           margin={0}

--- a/src/components/common/SearchBar/SearchBar.tsx
+++ b/src/components/common/SearchBar/SearchBar.tsx
@@ -1,3 +1,4 @@
+import { FormEvent } from 'react';
 import { MdSearch } from 'react-icons/md';
 
 import IconWrapper from '../IconWrapper';
@@ -28,9 +29,16 @@ const SearchBar = ({
   maxWidth,
   ...props
 }: SearchBarProps) => {
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (handleFormSubmit) {
+      handleFormSubmit();
+    }
+  };
+
   return (
     <SearchBarWrapper $maxWidth={maxWidth}>
-      <form onSubmit={handleFormSubmit}>
+      <form onSubmit={handleSubmit}>
         <Input
           width={'100%'}
           margin={0}

--- a/src/components/common/SearchBar/SearchBar.tsx
+++ b/src/components/common/SearchBar/SearchBar.tsx
@@ -50,12 +50,12 @@ const SearchBar = ({
           width={'100%'}
           margin={0}
           placeholder={'검색어를 입력해주세요.'}
-          style={{ paddingRight: '3rem' }}
+          style={{ paddingRight: '3.8rem', paddingLeft: '.5rem' }}
           {...props}
         />
       </form>
       <IconWrapper
-        $size={'xs'}
+        $size={'s'}
         onClick={handleSearchIcon}
       >
         <MdSearch />

--- a/src/components/common/SearchBar/SearchBar.tsx
+++ b/src/components/common/SearchBar/SearchBar.tsx
@@ -35,7 +35,11 @@ const SearchBar = ({
           width={'100%'}
           margin={0}
           placeholder={'검색어를 입력해주세요.'}
-          style={{ paddingRight: '3.8rem', paddingLeft: '.5rem' }}
+          style={{
+            paddingRight: '3.8rem',
+            paddingLeft: '.5rem',
+            height: '3rem',
+          }}
           {...props}
         />
       </form>

--- a/src/components/common/SearchBar/SearchBar.tsx
+++ b/src/components/common/SearchBar/SearchBar.tsx
@@ -1,0 +1,5 @@
+const SearchBar = () => {
+  return <div>검색바 컴포넌트</div>;
+};
+
+export default SearchBar;

--- a/src/components/common/SearchBar/SearchBar.type.ts
+++ b/src/components/common/SearchBar/SearchBar.type.ts
@@ -1,6 +1,6 @@
 export interface SearchBarProps {
   handleSearchIcon?: () => void;
-  handleSubmit?: () => void;
+  handleFormSubmit?: () => void;
   width?: string;
 }
 

--- a/src/components/common/SearchBar/SearchBar.type.ts
+++ b/src/components/common/SearchBar/SearchBar.type.ts
@@ -1,9 +1,9 @@
 export interface SearchBarProps {
   handleSearchIcon?: () => void;
   handleFormSubmit?: () => void;
-  width?: string;
+  maxWidth?: string;
 }
 
 export interface SearchBarStyleProps {
-  $width?: string;
+  $maxWidth?: string;
 }

--- a/src/components/common/SearchBar/SearchBar.type.ts
+++ b/src/components/common/SearchBar/SearchBar.type.ts
@@ -1,4 +1,9 @@
 export interface SearchBarProps {
   handleSearchIcon?: () => void;
   handleSubmit?: () => void;
+  width?: string;
+}
+
+export interface SearchBarStyleProps {
+  $width?: string;
 }

--- a/src/components/common/SearchBar/SearchBar.type.ts
+++ b/src/components/common/SearchBar/SearchBar.type.ts
@@ -1,4 +1,4 @@
-export interface SearchBarProps {
+export interface SearchBarProps extends React.HTMLAttributes<HTMLInputElement> {
   handleSearchIcon?: () => void;
   handleFormSubmit?: () => void;
   maxWidth?: string;

--- a/src/components/common/SearchBar/SearchBar.type.ts
+++ b/src/components/common/SearchBar/SearchBar.type.ts
@@ -1,0 +1,4 @@
+export interface SearchBarProps {
+  handleSearchIcon?: () => void;
+  handleSubmit?: () => void;
+}

--- a/src/components/common/SearchBar/index.ts
+++ b/src/components/common/SearchBar/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SearchBar';


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용

검색바 컴포넌트를 구현했습니다.

# 📷스크린샷(필요 시)

https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/174ebb7d-b029-4067-aa38-572ebbf82a16

# 사용 방법

```typescript

import { useForm } from 'react-hook-form';

import SearchBar from '@/components/common/SearchBar';

const TestPage = () => {
  const { handleSubmit } = useForm();

  const onSubmit = () => {
    alert('sumbit!');
  };

  return (
    <>
      <SearchBar
        handleSearchIcon={() => alert('검색됨!')}
        handleFormSubmit={handleSubmit(onSubmit)}
        maxWidth={'500px'}
      />
    </>
  );
};

export default TestPage;


```

위 예시는 TestPage에서 `react-hook-form`을 사용할 때 `handleSubmit` 이용을 확인하기 위해 작성한 코드입니다.
사용하실 때 `react-hook-form`의 `register` 등과 같은 요소는 SearchBar 컴포넌트에서 `{...props}`로 받습니다 !

`react-hook-form` 사용성을 고려할 때 [참고한 자료](https://tech.osci.kr/introduce-react-hook-form/)입니다.

# ✨PR Point

- `hendleSearchIcon` : 검색 아이콘에 할당 할 클릭 이벤트를 받습니다.
- `handleSubmit` :  input에 검색어 입력 후 엔터 했을 때 동작하는 submit 이벤트를 받습니다. (react-hook-form을 사용할 때 form 태그에 할당됩니다.)

- 검색바의 너비는 반응형으로 구현하기 위해 `width: 80%`로 설정해두었습니다.
- `maxWidth` : 검색바의 최대 너비를 지정할 수 있는 props 입니다. (문자열 타입이며 px, rem, %를 받을 수 있습니다.)
- 검색바의 최소 너비는 `224px`입니다. (갤럭시 폴드 환경을 고려했을 때 적절해보이는 너비로 설정했습니다.)
- 화면의 너비가 `MOBILE(768px)` 이하일 때는 `margin: 0 auto;` 로 가운데 정렬됩니다.

# 💬 논의사항
- 웹 환경에서의 검색바의 너비를 피그마 기준 `432px`로 고정해뒀는데 검색바의 너비를 받을 수 있는 `$width` 같은 props를 두는 것이 더 좋은 방향일까요 ? 
- `react-hook-form`의 `handleSubmit` 함수와 props인 `handleSubmit` 이름이 같아서 헷갈리지는 않은지 걱정됩니다. 만약 사용하는데 헷갈림이 있다면 props의 이름을 `handleFormSubmit`로 바꿀까 하는데 어떻게 생각하시나요?
- `hendleSearchIcon`, `handleSubmit` 타입이 `() => void`입니다. `react-hook-form`의 `getValue` 함수 사용을 고려하여 매개변수 타입을 정해두진 않았습니다.
`(key: string) => void` 와 같이 검색을 실행하는 함수의 매개변수로 검색어를 넣을 수도 있다면 **매개변수의 타입도 설정 해둬야할까요?**

- `react-hook-form` 사용성 고려를 잘 했을까요 ?? 
  - 중점적으로 고려한 부분은 `register`와 `handleSubmit`입니다. 따라서 `register`는 Input 컴포넌트의 `{...props}`로 받도록 했고, `handleSubmit` 함수는 SearchBar의 `handleSubmit` props로 받도록 제작했습니다.

- 더 나은 방법이나 좋은 의견 환영입니다 !!