### PR TITLE
[#42] 전역 상태 모달 v1.0.0

### DIFF
--- a/src/components/common/ModalLayout/ModalLayout.style.ts
+++ b/src/components/common/ModalLayout/ModalLayout.style.ts
@@ -1,0 +1,71 @@
+import styled from 'styled-components';
+
+import {
+  FONT_SEMI_BOLD,
+  MOBILE,
+  MOBILE_FONT_SIZE,
+  MODAL_BACKGROUND,
+  MODAL_LAYOUT,
+} from '@/constants';
+
+export const ModalDimmer = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(1.2px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: ${MODAL_BACKGROUND};
+`;
+
+export const ModalBody = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  max-width: 800px;
+  max-height: 600px;
+  min-width: 270px;
+  min-height: 100px;
+  background-color: #ffffff;
+  border-radius: 10px;
+  z-index: ${MODAL_LAYOUT};
+
+  @media screen and (max-width: ${MOBILE}px) {
+    max-width: 90%;
+    max-height: 60%;
+  }
+`;
+
+export const ModalTitle = styled.div`
+  display: flex;
+  width: 100%;
+  box-sizing: border-box;
+  justify-content: center;
+  padding: 1rem;
+  font-weight: bold;
+  font-size: 2rem;
+  border-bottom: 1px solid #cbcbcb;
+`;
+
+export const ModalContents = styled.div`
+  font-size: 1.6rem;
+  padding: 1rem;
+  overflow-y: scroll;
+`;
+
+export const MobileModalCloseArea = styled.div`
+  display: flex;
+  padding: 0.5rem 0;
+  width: 100%;
+  height: 2rem;
+  font-size: ${MOBILE_FONT_SIZE}rem;
+  align-items: center;
+  justify-content: center;
+  border-top: 1px solid #cbcbcb;
+  cursor: pointer;
+  font-weight: ${FONT_SEMI_BOLD};
+`;

--- a/src/components/common/ModalLayout/ModalLayout.style.ts
+++ b/src/components/common/ModalLayout/ModalLayout.style.ts
@@ -68,4 +68,9 @@ export const MobileModalCloseArea = styled.div`
   border-top: 1px solid ${(props) => props.theme.gray_200};
   cursor: pointer;
   font-weight: ${FONT_SEMI_BOLD};
+
+  &:active {
+    background-color: ${(props) => props.theme.gray_200};
+    border-radius: 10px;
+  }
 `;

--- a/src/components/common/ModalLayout/ModalLayout.style.ts
+++ b/src/components/common/ModalLayout/ModalLayout.style.ts
@@ -45,7 +45,7 @@ export const ModalTitle = styled.div`
   width: 100%;
   box-sizing: border-box;
   justify-content: center;
-  padding: 1rem;
+  padding: 1rem 5rem;
   font-weight: bold;
   font-size: 2rem;
   border-bottom: 1px solid #cbcbcb;
@@ -65,7 +65,7 @@ export const MobileModalCloseArea = styled.div`
   font-size: ${MOBILE_FONT_SIZE}rem;
   align-items: center;
   justify-content: center;
-  border-top: 1px solid #cbcbcb;
+  border-top: 1px solid ${(props) => props.theme.gray_200};
   cursor: pointer;
   font-weight: ${FONT_SEMI_BOLD};
 `;

--- a/src/components/common/ModalLayout/ModalLayout.style.ts
+++ b/src/components/common/ModalLayout/ModalLayout.style.ts
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
 
 import {
+  BORDER_MOBILE,
+  BORDER_WEB,
   FONT_SEMI_BOLD,
   MOBILE,
   MOBILE_FONT_SIZE,
@@ -31,12 +33,13 @@ export const ModalBody = styled.div`
   min-width: 270px;
   min-height: 100px;
   background-color: #ffffff;
-  border-radius: 10px;
+  border-radius: ${BORDER_WEB}px;
   z-index: ${MODAL_LAYOUT};
 
   @media screen and (max-width: ${MOBILE}px) {
     max-width: 90%;
     max-height: 60%;
+    border-radius: ${BORDER_MOBILE}px;
   }
 `;
 
@@ -48,13 +51,20 @@ export const ModalTitle = styled.div`
   padding: 1rem 5rem;
   font-weight: bold;
   font-size: 2rem;
-  border-bottom: 1px solid #cbcbcb;
+  border-bottom: 1px solid ${(props) => props.theme.border_color};
+
+  @media screen and (max-width: ${MOBILE}px) {
+    font-size: 1.8rem;
+  }
 `;
 
 export const ModalContents = styled.div`
   font-size: 1.6rem;
   padding: 1rem;
   overflow-y: scroll;
+  @media screen and (max-width: ${MOBILE}px) {
+    font-size: 1.4rem;
+  }
 `;
 
 export const MobileModalCloseArea = styled.div`
@@ -65,12 +75,16 @@ export const MobileModalCloseArea = styled.div`
   font-size: ${MOBILE_FONT_SIZE}rem;
   align-items: center;
   justify-content: center;
-  border-top: 1px solid ${(props) => props.theme.gray_200};
+  border-top: 1px solid ${(props) => props.theme.border_color};
   cursor: pointer;
   font-weight: ${FONT_SEMI_BOLD};
 
   &:active {
     background-color: ${(props) => props.theme.gray_200};
-    border-radius: 10px;
+    border-radius: ${BORDER_WEB}px;
+  }
+
+  @media screen and (max-width: ${MOBILE}px) {
+    border-radius: ${BORDER_MOBILE}px;
   }
 `;

--- a/src/components/common/ModalLayout/ModalLayout.style.ts
+++ b/src/components/common/ModalLayout/ModalLayout.style.ts
@@ -11,27 +11,31 @@ import {
 } from '@/constants';
 
 export const ModalDimmer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
   position: fixed;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
+
   background-color: rgba(0, 0, 0, 0.4);
   backdrop-filter: blur(1.2px);
-  display: flex;
-  justify-content: center;
-  align-items: center;
   z-index: ${MODAL_BACKGROUND};
 `;
 
 export const ModalBody = styled.div`
-  position: relative;
   display: flex;
   flex-direction: column;
   max-width: 800px;
   max-height: 600px;
   min-width: 270px;
   min-height: 100px;
+
+  position: relative;
+
   background-color: #ffffff;
   border-radius: ${BORDER_WEB}px;
   z-index: ${MODAL_LAYOUT};
@@ -45,10 +49,11 @@ export const ModalBody = styled.div`
 
 export const ModalTitle = styled.div`
   display: flex;
-  width: 100%;
-  box-sizing: border-box;
   justify-content: center;
+  box-sizing: border-box;
+  width: 100%;
   padding: 1rem 5rem;
+
   font-weight: bold;
   font-size: 2rem;
   border-bottom: 1px solid ${(props) => props.theme.border_color};
@@ -69,12 +74,13 @@ export const ModalContents = styled.div`
 
 export const MobileModalCloseArea = styled.div`
   display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 0.5rem 0;
   width: 100%;
   height: 2rem;
+
   font-size: ${MOBILE_FONT_SIZE}rem;
-  align-items: center;
-  justify-content: center;
   border-top: 1px solid ${(props) => props.theme.border_color};
   cursor: pointer;
   font-weight: ${FONT_SEMI_BOLD};

--- a/src/components/common/ModalLayout/ModalLayout.tsx
+++ b/src/components/common/ModalLayout/ModalLayout.tsx
@@ -1,0 +1,55 @@
+import { MdClose } from 'react-icons/md';
+
+import { useModal } from '@/hooks/useModal';
+import useResize from '@/hooks/useResize';
+
+import IconWrapper from '../IconWrapper';
+import {
+  MobileModalCloseArea,
+  ModalBody,
+  ModalContents,
+  ModalDimmer,
+  ModalTitle,
+} from './ModalLayout.style';
+
+const ModalLayout = () => {
+  const { isOpen, modalState, setModalClose } = useModal();
+  const { isMobileSize } = useResize();
+
+  const onDimmerClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.currentTarget !== event.target) return;
+    setModalClose();
+  };
+
+  return (
+    <>
+      {isOpen && (
+        <ModalDimmer onClick={onDimmerClick}>
+          <ModalBody>
+            <ModalTitle>{modalState.title}</ModalTitle>
+            <ModalContents>{modalState.content}</ModalContents>
+            {isMobileSize ? (
+              <MobileModalCloseArea onClick={setModalClose}>
+                <span>닫기</span>
+              </MobileModalCloseArea>
+            ) : (
+              <IconWrapper
+                style={{
+                  position: 'absolute',
+                  right: 0,
+                }}
+                $isBackground
+                $size={'m'}
+                onClick={setModalClose}
+              >
+                <MdClose />
+              </IconWrapper>
+            )}
+          </ModalBody>
+        </ModalDimmer>
+      )}
+    </>
+  );
+};
+
+export default ModalLayout;

--- a/src/components/common/ModalLayout/ModalLayout.tsx
+++ b/src/components/common/ModalLayout/ModalLayout.tsx
@@ -16,7 +16,7 @@ const ModalLayout = () => {
   const { isOpen, modalState, setModalClose } = useModal();
   const { isMobileSize } = useResize();
 
-  const onDimmerClick = (event: React.MouseEvent<HTMLDivElement>) => {
+  const handleDimmerClick = (event: React.MouseEvent<HTMLDivElement>) => {
     if (event.currentTarget !== event.target) return;
     setModalClose();
   };
@@ -24,7 +24,7 @@ const ModalLayout = () => {
   return (
     <>
       {isOpen && (
-        <ModalDimmer onClick={onDimmerClick}>
+        <ModalDimmer onClick={handleDimmerClick}>
           <ModalBody>
             <ModalTitle>{modalState.title}</ModalTitle>
             <ModalContents>{modalState.content}</ModalContents>

--- a/src/components/common/ModalLayout/index.ts
+++ b/src/components/common/ModalLayout/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ModalLayout';

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 
 import { modalStore, ModalType } from '@/stores';
+import { disableScrollLock, enableScrollLock } from '@/utils/bodyScrollLock';
 
 export const useModal = () => {
   const { isOpen, title, content, callBack, openModal, closeModal } =
@@ -8,6 +9,7 @@ export const useModal = () => {
 
   const setModalOpen = useCallback(
     ({ title, content, callBack }: ModalType) => {
+      enableScrollLock();
       openModal({
         title: title,
         content: content,
@@ -18,6 +20,7 @@ export const useModal = () => {
   );
 
   const setModalClose = useCallback(() => {
+    disableScrollLock();
     closeModal();
   }, [closeModal]);
 

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,0 +1,30 @@
+import { useCallback } from 'react';
+
+import { modalStore, ModalType } from '@/stores';
+
+export const useModal = () => {
+  const { isOpen, title, content, callBack, openModal, closeModal } =
+    modalStore();
+
+  const setModalOpen = useCallback(
+    ({ title, content, callBack }: ModalType) => {
+      openModal({
+        title: title,
+        content: content,
+        callBack,
+      });
+    },
+    [openModal]
+  );
+
+  const setModalClose = useCallback(() => {
+    closeModal();
+  }, [closeModal]);
+
+  return {
+    isOpen,
+    modalState: { title, content, callBack },
+    setModalOpen,
+    setModalClose,
+  };
+};

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -20,8 +20,13 @@ export const useModal = () => {
   );
 
   const setModalClose = useCallback(() => {
-    disableScrollLock();
-    closeModal();
+    if (window.confirm('작성을 종료하시겠습니까?')) {
+      disableScrollLock();
+      closeModal();
+      return;
+    } else {
+      return;
+    }
   }, [closeModal]);
 
   return {

--- a/src/hooks/useResize.tsx
+++ b/src/hooks/useResize.tsx
@@ -14,7 +14,7 @@ const useResize = () => {
       clearTimeout(timeoutId);
       timeoutId = setTimeout(() => {
         setIsMobileSize(window.innerWidth < MOBILE);
-      }, 500); // 500ms 디바운싱 시간 설정
+      }, 200); // 200ms 디바운싱 시간 설정
     };
 
     window.addEventListener('resize', handleResize);

--- a/src/hooks/useResize.tsx
+++ b/src/hooks/useResize.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+
+import { MOBILE } from '@/constants';
+
+const useResize = () => {
+  const [isMobileSize, setIsMobileSize] = useState<boolean>(
+    window.innerWidth < MOBILE
+  );
+
+  useEffect(() => {
+    let timeoutId: NodeJS.Timeout;
+
+    const handleResize = () => {
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => {
+        setIsMobileSize(window.innerWidth < MOBILE);
+      }, 500); // 500ms 디바운싱 시간 설정
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      clearTimeout(timeoutId); // 컴포넌트가 unmount 되기 전에 timeout 정리
+    };
+  }, []);
+
+  return {
+    isMobileSize,
+    setIsMobileSize,
+  };
+};
+
+export default useResize;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import { Route, Routes } from 'react-router-dom';
 
+import Modal from '@/components/common/Modal';
 import { PATH } from '@/constants/router';
 import {
   AuthPage,
@@ -62,6 +63,7 @@ const Router = () => {
           />
         </Route>
       </Routes>
+      <Modal />
     </>
   );
 };

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,5 @@
 import { Route, Routes } from 'react-router-dom';
 
-import Modal from '@/components/common/Modal';
 import { PATH } from '@/constants/router';
 import {
   AuthPage,
@@ -63,7 +62,6 @@ const Router = () => {
           />
         </Route>
       </Routes>
-      <Modal />
     </>
   );
 };

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,6 @@
 import { Route, Routes } from 'react-router-dom';
 
-import Modal from '@/components/common/Modal';
+import ModalLayout from '@/components/common/ModalLayout';
 import { PATH } from '@/constants/router';
 import {
   AuthPage,
@@ -63,7 +63,7 @@ const Router = () => {
           />
         </Route>
       </Routes>
-      <Modal />
+      <ModalLayout />
     </>
   );
 };

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import { Route, Routes } from 'react-router-dom';
 
+import Modal from '@/components/common/Modal';
 import {
   AuthPage,
   HubPage,
@@ -61,6 +62,7 @@ const Router = () => {
           />
         </Route>
       </Routes>
+      <Modal />
     </>
   );
 };

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -19,3 +19,30 @@ export const themeStore = create<ThemeState>()(
     }
   )
 );
+
+interface ModalType {
+  title: string;
+  content: React.ReactNode;
+  callBack?: () => void;
+}
+interface ModalState extends ModalType {
+  isOpen: boolean;
+  openModal: (modalData: ModalType) => void;
+  closeModal: () => void;
+}
+
+export const modalStore = create<ModalState>((set) => ({
+  isOpen: false,
+  title: '',
+  content: '',
+  callBack: undefined,
+  openModal: (modalData: ModalType) =>
+    set({
+      isOpen: true,
+      title: modalData.title,
+      content: modalData.content,
+      callBack: modalData.callBack,
+    }),
+  closeModal: () =>
+    set({ isOpen: false, title: '', content: '', callBack: undefined }),
+}));

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -20,12 +20,12 @@ export const themeStore = create<ThemeState>()(
   )
 );
 
-interface ModalType {
+export interface ModalType {
   title: string;
   content: React.ReactNode;
   callBack?: () => void;
 }
-interface ModalState extends ModalType {
+export interface ModalState extends ModalType {
   isOpen: boolean;
   openModal: (modalData: ModalType) => void;
   closeModal: () => void;

--- a/src/utils/bodyScrollLock.ts
+++ b/src/utils/bodyScrollLock.ts
@@ -1,0 +1,44 @@
+import { detectMobileDevice } from './isMobile';
+
+export const enableScrollLock = () => {
+  const { body } = document;
+  const isMobile = detectMobileDevice();
+
+  if (!body.getAttribute('scrollY')) {
+    const pageY = window.scrollY;
+
+    body.setAttribute('scrollY', pageY.toString());
+
+    body.style.overflow = 'hidden';
+    body.style.position = 'fixed';
+    body.style.left = '0px';
+    body.style.right = '0px';
+    body.style.bottom = '0px';
+    body.style.top = `-${pageY}px`;
+    console.log(pageY);
+    if (!isMobile) {
+      body.style.paddingRight = '0.4rem';
+    }
+  }
+};
+
+export const disableScrollLock = () => {
+  const { body } = document;
+  const isMobile = detectMobileDevice();
+
+  if (body.getAttribute('scrollY')) {
+    body.style.removeProperty('overflow');
+    body.style.removeProperty('position');
+    body.style.removeProperty('top');
+    body.style.removeProperty('left');
+    body.style.removeProperty('right');
+    body.style.removeProperty('bottom');
+    if (!isMobile) {
+      body.style.removeProperty('padding-right');
+    }
+
+    window.scrollTo(0, Number(body.getAttribute('scrollY')));
+
+    body.removeAttribute('scrollY');
+  }
+};

--- a/src/utils/bodyScrollLock.ts
+++ b/src/utils/bodyScrollLock.ts
@@ -15,7 +15,6 @@ export const enableScrollLock = () => {
     body.style.right = '0px';
     body.style.bottom = '0px';
     body.style.top = `-${pageY}px`;
-    console.log(pageY);
     if (!isMobile) {
       body.style.paddingRight = '0.4rem';
     }

--- a/src/utils/isMobile.ts
+++ b/src/utils/isMobile.ts
@@ -1,0 +1,14 @@
+export const detectMobileDevice = () => {
+  const agent = window.navigator.userAgent;
+  const mobileRegex = [
+    /Android/i,
+    /iPhone/i,
+    /iPad/i,
+    /iPod/i,
+    /BlackBerry/i,
+    /Windows Phone/i,
+    /Mobi/i,
+  ];
+
+  return mobileRegex.some((mobile) => agent.match(mobile));
+};


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용
우선 사과의 말씀 드립니다,,, 생각보다 모달을 구현하다보니 해야할 게 정말 많아서 같이 구현하였습니다. 
또한 선언한 기간보다 기간이 길어졌는데, 더 열심히 해보겠습니다.

# 📷스크린샷
### 🖥️웹 환경 모달
[kiwing_modal_v1.0.0.webm](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/90549862/f55de2fd-f2b3-4d19-8c4e-722f95fbc977)

### 📱모바일 환경 모달
[kiwing_modal_mobile_v1.0.0.webm](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/90549862/1e10f892-64fa-4ea5-8380-2fae5877f2c4)

# ✨PR Point
## 📋구현 내역 및 설명
### 📌modalStore를 추가하였습니다.
store/index.ts에 modalStore와 관련 타입을 export 형태로 선언하였습니다.

전역 상태는 isOpen, title, content, callBack의 `단일 상태`만을 가집니다. 이러한 특성으로 인해서 모달은 항상 단일 개체만 생성이 가능합니다. 물론 모달을 생성 후 다른 모달로 이동은 가능하지만, 추천드리지는 않습니다.
```ts
export interface ModalType {
  title: string;
  content: React.ReactNode;
  callBack?: () => void;
}
export interface ModalState extends ModalType {
  isOpen: boolean;
  openModal: (modalData: ModalType) => void;
  closeModal: () => void;
}

export const modalStore = create<ModalState>((set) => ({
  isOpen: false,
  title: '',
  content: '',
  callBack: undefined,
  openModal: (modalData: ModalType) =>
    set({
      isOpen: true,
      title: modalData.title,
      content: modalData.content,
      callBack: modalData.callBack,
    }),
  closeModal: () =>
    set({ isOpen: false, title: '', content: '', callBack: undefined }),
}));
```

### 📌useModal 훅을 추가하였습니다.
모달을 더 쉽게 사용하실 수 있도록 hook 형태로 추상화 하였습니다. 
이렇게 추상화할 경우 사용하실때 `setModalOpen` 과 `setModalClose`만 가져다가 사용하시면 됩니다.

또한 모달이 생겼음에도 불구하고 뒷 배경이 스크롤 되는 이슈가 있었습니다.
해당 이슈를 하단에 통합적으로 기술하겠습니다. 이 코드에서는 
`enableScrollLock();`, `disableScrollLock();`이 관련 코드입니다.
```ts
import { useCallback } from 'react';

import { modalStore, ModalType } from '@/stores';
import { disableScrollLock, enableScrollLock } from '@/utils/bodyScrollLock';

export const useModal = () => {
  const { isOpen, title, content, callBack, openModal, closeModal } =
    modalStore();

  const setModalOpen = useCallback(
    ({ title, content, callBack }: ModalType) => {
      enableScrollLock();
      openModal({
        title: title,
        content: content,
        callBack,
      });
    },
    [openModal]
  );

  const setModalClose = useCallback(() => {
    disableScrollLock();
    closeModal();
  }, [closeModal]);

  return {
    isOpen,
    modalState: { title, content, callBack },
    setModalOpen,
    setModalClose,
  };
};
```

### 📌ModalLayout 폴더
![image](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/90549862/a40e8b6d-5748-4cdc-b665-599fe5fda4db)

해당 레이아웃 형태를 잡아주는 코드입니다.
- Title과 웹에서 우상단 X 버튼, 모바일에서 하단 닫기 버튼을 지원합니다.
- content에 여러분이 원하는 모달 내부 컴포넌트를 입력하시면 됩니다.
- Dimmer영역, 즉 모달영역을 제외한 어둡고 blur처리된 배경을 클릭하면 모달이 닫힙니다.

### 📌useResize훅을 구현하였습니다.
웹 환경에서도 모달의 레이아웃이 깨지는 현상을 방지하기 위해, 현재 화면 사이즈 측정이 필요했고, 
해당 기능을 구현하기 위해 useResize 훅을 구현하였습니다. 
현주님의 이전 팀 코드를 참조하였습니다. 
어려운 내용은 없고 간단하게 settimeout을 활용해 디바운싱 로직을 추가하였습니다.

### 📌isMobile 유틸 함수를 구현하였습니다.
접속한 기기의 agent에 접근하여 모바일 여부를 판단 후 boolean값을 반환합니다.
후술할 모달 레이아웃이 깨지는 현상을 방지하기 위해 사용하였습니다.

### 📌bodyScrollLock.ts 유틸 함수를 구현하였습니다.
모달 뒷 배경이 스크롤되는 현상이 있었고 해당 문제점은 꽤나 유명한 이슈...였습니다.
관련해서 유명한 라이브러리인 [body-scroll-lock](https://github.com/willmcpo/body-scroll-lock) 라이브러리가 존재하지만, 
해당 라이브러리를 사용했을 때 IOS환경, 즉 아이폰 사파리에서 제대로 동작하지 않는다는 문제점이 있다고 알고 있고
또한 해당 라이브러리는 현재 유지보수된지 2년이 넘어간 라이브러리로 사용에 있어서 찜찜함이 있었습니다.

이런 문제점을 해결하고자 직접 구현했는데 관련된 코드 로직이 웹상에 꽤 많이 존재하여 구현에 큰 어려움은 없었습니다.
다만 문제점으로 발생했던 것은 스크롤바의 존재로 인한 body태그 코드들의 레이아웃이 깨진다는 문제점이 있었습니다.

[kiwing_modal_back.webm](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/90549862/65a4e6d1-1be0-4ff5-b044-f6743b85993a)

이처럼 body의 레이아웃이 깨졌고, 만약 내부에 동작하는 컴포넌트들이 많을수록 문제가 생길것이라고 판단하였습니다.

원인은 웹 페이지에서의 스크롤 바가 잡고있는 0.4rem 만큼의 width였습니다.
해당 width가 모달이 켜지면 사라졌다가 모달이 꺼지면 다시 생성되어서 레이아웃이 깨지는 것처럼 보였고, 이로 인한 **높이 차이 발생으로 인해 스크롤이 제대로 위치하지 않는 현상**도 같이 발생하였습니다.

이를 해결하기 위해 웹 환경에서는 아래와 같이 0.4rem의 paddingRight값을 주어 해결할 수 있는데요.
이때의 맹점은, 모바일 환경에서 스크롤은 스크롤 바가 width를 차지하지 않고 최상단으로 올라가서 약간 가상선택자처럼 기존의 body의 영향을 끼치지 않는다는 점이였습니다.

따라서 해당 코드에서 모바일, 웹을 구분할 코드가 필요했고 앞서 서술한 isMobile 함수의 필요성이 이때 생기게 되었습니다.
```
    if (!isMobile) {
      body.style.paddingRight = '0.4rem';

 ... 중략

    if (!isMobile) {
      body.style.removeProperty('padding-right');
    }
```
근데 쓰면서 생각난건데 아이폰 쪽에 테스트를 요청드렸어야했는데,.,... 까먹....,.,.,.
혹시라도 문제생기면 울고 싶을 것 같네요.

## ✨사용법
사용법은 금일 아침에 설명드린 방식과 유사합니다.

빠른 테스트환경을 위해 제가 테스트한 코드를 추가합니다.
보시다시피 모달에 특정 페이지를 입력할 수 있는 일도 가능합니다.

ReactNode면 상관없습니다. 따라서 따로 Modal 컴포넌트를 만들고 import하셔서 입력하셔도 되고, 
구현하는 페이지에서 입력하셔도 무방합니다.
```ts
// Test.tsx
import { useModal } from '@/hooks/useModal';
import { ModalType } from '@/stores';

import Temp from './temp';

const TestPage = () => {
  const { setModalOpen } = useModal();

  const handler = (): void => {
    console.log(`안뇽하세요 핸들러 함수입니다.`);
  };

  const modalData1: ModalType = {
    title: '컴포넌트를 해당 content에서 직접 작성 형태, 함수도 직접 연동 가능',
    content: (
      <>
        <div>
          kiwing 만세 kiwing 만세 kiwing 만세 kiwing 만세 kiwing 만세 kiwing
          만세 kiwing 만세 kiwing 만세 kiwing 만세 kiwing 만세 kiwing 만세
          kiwing 만세 kiwing 만세 kiwing 만세 kiwing 만세 kiwing 만세 kiwing
          만세 kiwing 만세 kiwing 만세 kiwing 만세 kiwing 만세 kiwing 만세
        </div>
        <button onClick={handler}>handler</button>
        {/* 하지만 아래와 같은 형태는 렌더링이 안되어 사용이 불가능합니다!  */}
        {/* <button onClick={modalState.callBack}>handler</button> */}
      </>
    ),
  };

  const modalData2: ModalType = {
    title:
      '컴포넌트를 import해서 사용하는 형태, 함수는 callBack을 사용하는 모달',
    content: <Temp />,
    callBack: handler,
  };

  return (
    <>
      <div>테스트 페이지 입니다. </div>
      <button
        style={{ fontSize: '2rem' }}
        onClick={() => setModalOpen(modalData1)}
      >
        1. 중첩으로 모달 내려주기
      </button>
      <div>테스트 페이지 입니다. </div>
      <button
        style={{ fontSize: '2rem' }}
        onClick={() => setModalOpen(modalData2)}
      >
        2. 컴포넌트 형태, callBack을 사용하는 모달!
      </button>
    </>
  );
};

export default TestPage;


// Temp.tsx
import { useModal } from '@/hooks/useModal';

const Temp = () => {
  const { modalState } = useModal();

  return (
    <>
      <div>
        kiwing 화이팅 kiwing 화이팅 kiwing 화이팅 kiwing 화이팅 kiwing 화이팅
        kiwing 화이팅 kiwing 화이팅 kiwing 화이팅 kiwing 화이팅 kiwing 화이팅
        kiwing 화이팅 kiwing 화이팅 kiwing 화이팅 kiwing 화이팅 kiwing 화이팅
        kiwing 화이팅
      </div>
      <button onClick={modalState.callBack}>Callback by zustand!</button>
    </>
  );
};

export default Temp;
```

이상 설명은 다 끝났습니다..!
읽으시느라 고생 많으셨습니다.

제가 개인적으로 해야할 것 혹은 생각나는 것은
- 세부적인 모달 너비, 높이 픽셀 조정
- 다크모드 지원
- 웹 기준 X 버튼 위치 재고려

요런 것들이 있습니다... 어떠한 피드백이든 환영입니다! 자유롭고 편하게 의견 주시면 감사하겠습니다!