### PR TITLE
[#28] UserInfoCard 컴포넌트 구현 v1.0.0

### DIFF
--- a/src/components/common/UserInfoCard/UserInfoCard.style.ts
+++ b/src/components/common/UserInfoCard/UserInfoCard.style.ts
@@ -13,6 +13,8 @@ export const UserInfoWrapper = styled(Row)`
   padding: 2rem;
   box-sizing: border-box;
   align-items: center;
+  /* TODO: constans의 card_border로 수정 */
+  border-radius: 1.5rem;
 
   & > :nth-child(1),
   & > :nth-child(3) {
@@ -21,6 +23,7 @@ export const UserInfoWrapper = styled(Row)`
 
   & > :nth-child(2) {
     flex-grow: 1;
+    overflow: hidden;
   }
 `;
 
@@ -76,11 +79,7 @@ export const UserInfoLink = styled(Row)`
   gap: 0.5rem;
   align-items: center;
   & > a {
-    @media screen and (max-width: ${MOBILE}px) {
-      width: 13rem;
-    }
-
-    width: 35rem;
+    width: 100%;
     color: ${({ theme }) => theme.gray_400};
     text-decoration: none;
     line-height: normal;

--- a/src/components/common/UserInfoCard/UserInfoCard.style.ts
+++ b/src/components/common/UserInfoCard/UserInfoCard.style.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { FONT_BOLD, MOBILE } from '@/constants';
+import { FONT_BOLD, FONT_REGULAR, MOBILE } from '@/constants';
 import { Col, Row } from '@/styles/globalStyles';
 
 export const UserInfoWrapper = styled(Row)`
@@ -86,4 +86,14 @@ export const UserInfoIconWrapper = styled(Col)`
   height: 100%;
   justify-content: space-between;
   color: ${({ theme }) => theme.primary_color};
+`;
+
+export const NotDataText = styled.div`
+  @media screen and (max-width: ${MOBILE}px) {
+    font-size: 0.8rem;
+  }
+
+  color: ${({ theme }) => theme.gray_500}80;
+  font-size: 1.2rem;
+  font-weight: ${FONT_REGULAR};
 `;

--- a/src/components/common/UserInfoCard/UserInfoCard.style.ts
+++ b/src/components/common/UserInfoCard/UserInfoCard.style.ts
@@ -29,6 +29,7 @@ export const UserInfoContentsWrapper = styled(Col)`
     padding: 0 1rem;
   }
 
+  width: 100%;
   padding: 0 2rem;
 `;
 
@@ -59,26 +60,27 @@ export const UserInfoBadgeWrapper = styled.div`
 `;
 
 export const UserInfoLinkWrapper = styled(Col)`
+  width: 100%;
   margin-top: 1rem;
-  gap: 0.5rem;
+  gap: 1rem;
 `;
 
 export const UserInfoLink = styled(Row)`
   @media screen and (max-width: ${MOBILE}px) {
-    font-size: 0.8rem;
+    font-size: 1rem;
   }
 
+  width: 100%;
   color: ${({ theme }) => theme.primary_color};
   font-size: 1.2rem;
-  gap: 0.3rem;
+  gap: 0.5rem;
   align-items: center;
   & > a {
     width: 80%;
-    color: ${({ theme }) => theme.gray_500};
+    color: ${({ theme }) => theme.gray_400};
     text-decoration: none;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    word-break: break-word;
+    line-height: normal;
   }
 `;
 
@@ -90,7 +92,7 @@ export const UserInfoIconWrapper = styled(Col)`
 
 export const NotDataText = styled.div`
   @media screen and (max-width: ${MOBILE}px) {
-    font-size: 0.8rem;
+    font-size: 1rem;
   }
 
   color: ${({ theme }) => theme.gray_500}80;

--- a/src/components/common/UserInfoCard/UserInfoCard.style.ts
+++ b/src/components/common/UserInfoCard/UserInfoCard.style.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { FONT_REGULAR, MOBILE } from '@/constants';
+import { FONT_BOLD, MOBILE } from '@/constants';
 import { Col, Row } from '@/styles/globalStyles';
 
 export const UserInfoWrapper = styled(Row)`
@@ -49,7 +49,7 @@ export const UserInfoNickname = styled.div`
 
   color: ${({ theme }) => theme.primary_color};
   font-size: 2rem;
-  font-weight: ${FONT_REGULAR};
+  font-weight: ${FONT_BOLD};
 `;
 
 export const UserInfoBadgeWrapper = styled.div`

--- a/src/components/common/UserInfoCard/UserInfoCard.style.ts
+++ b/src/components/common/UserInfoCard/UserInfoCard.style.ts
@@ -76,11 +76,17 @@ export const UserInfoLink = styled(Row)`
   gap: 0.5rem;
   align-items: center;
   & > a {
-    width: 80%;
+    @media screen and (max-width: ${MOBILE}px) {
+      width: 13rem;
+    }
+
+    width: 35rem;
     color: ${({ theme }) => theme.gray_400};
     text-decoration: none;
-    word-break: break-word;
     line-height: normal;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
   }
 `;
 

--- a/src/components/common/UserInfoCard/UserInfoCard.style.ts
+++ b/src/components/common/UserInfoCard/UserInfoCard.style.ts
@@ -90,7 +90,17 @@ export const UserInfoIconWrapper = styled(Col)`
   color: ${({ theme }) => theme.primary_color};
 `;
 
-export const NotDataText = styled.div`
+export const NoTags = styled.div`
+  @media screen and (max-width: ${MOBILE}px) {
+    font-size: 1rem;
+  }
+
+  color: ${({ theme }) => theme.gray_500}80;
+  font-size: 1.2rem;
+  font-weight: ${FONT_REGULAR};
+`;
+
+export const NoLinks = styled.div`
   @media screen and (max-width: ${MOBILE}px) {
     font-size: 1rem;
   }

--- a/src/components/common/UserInfoCard/UserInfoCard.style.ts
+++ b/src/components/common/UserInfoCard/UserInfoCard.style.ts
@@ -1,0 +1,89 @@
+import styled from 'styled-components';
+
+import { FONT_REGULAR, MOBILE } from '@/constants';
+import { Col, Row } from '@/styles/globalStyles';
+
+export const UserInfoWrapper = styled(Row)`
+  @media screen and (max-width: ${MOBILE}px) {
+    padding: 1rem;
+  }
+
+  background-color: ${({ theme }) => theme.background_color};
+  width: 100%;
+  padding: 2rem;
+  box-sizing: border-box;
+  align-items: center;
+
+  & > :nth-child(1),
+  & > :nth-child(3) {
+    flex-shrink: 0;
+  }
+
+  & > :nth-child(2) {
+    flex-grow: 1;
+  }
+`;
+
+export const UserInfoContentsWrapper = styled(Col)`
+  @media screen and (max-width: ${MOBILE}px) {
+    padding: 0 1rem;
+  }
+
+  padding: 0 2rem;
+`;
+
+export const UserInfoNicknameBadgeWrapper = styled(Row)`
+  @media screen and (max-width: ${MOBILE}px) {
+    gap: 0.8rem;
+  }
+
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+`;
+
+export const UserInfoNickname = styled.div`
+  @media screen and (max-width: ${MOBILE}px) {
+    font-size: 1.6rem;
+  }
+
+  color: ${({ theme }) => theme.primary_color};
+  font-size: 2rem;
+  font-weight: ${FONT_REGULAR};
+`;
+
+export const UserInfoBadgeWrapper = styled.div`
+  & > span {
+    margin: 0.1rem;
+  }
+`;
+
+export const UserInfoLinkWrapper = styled(Col)`
+  margin-top: 1rem;
+  gap: 0.5rem;
+`;
+
+export const UserInfoLink = styled(Row)`
+  @media screen and (max-width: ${MOBILE}px) {
+    font-size: 0.8rem;
+  }
+
+  color: ${({ theme }) => theme.primary_color};
+  font-size: 1.2rem;
+  gap: 0.3rem;
+  align-items: center;
+  & > a {
+    width: 80%;
+    color: ${({ theme }) => theme.gray_500};
+    text-decoration: none;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+`;
+
+export const UserInfoIconWrapper = styled(Col)`
+  height: 100%;
+  justify-content: space-between;
+  color: ${({ theme }) => theme.primary_color};
+`;

--- a/src/components/common/UserInfoCard/UserInfoCard.tsx
+++ b/src/components/common/UserInfoCard/UserInfoCard.tsx
@@ -9,6 +9,7 @@ import Badge from '../Badge';
 import IconWrapper from '../IconWrapper';
 import ShadowBox from '../ShadowBox';
 import {
+  NotDataText,
   UserInfoBadgeWrapper,
   UserInfoContentsWrapper,
   UserInfoIconWrapper,
@@ -18,6 +19,7 @@ import {
   UserInfoNicknameBadgeWrapper,
   UserInfoWrapper,
 } from './UserInfoCard.style';
+import { UserInfoCardProps } from './UserInfoCard.type';
 
 /**
  *
@@ -29,7 +31,12 @@ import {
  */
 
 // TODO: API 명세서 나오면 데이터 형식에 맞게 props 설정하기
-const UserInfoCard = () => {
+const UserInfoCard = ({
+  userImage,
+  userName,
+  tags,
+  links,
+}: UserInfoCardProps) => {
   const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
   let timer = null;
 
@@ -55,56 +62,42 @@ const UserInfoCard = () => {
       style={{ minWidth: '280px', margin: '0 auto' }}
     >
       <UserInfoWrapper>
-        <Avatar $size={viewportWidth <= MOBILE ? 'mobile' : 'pc'} />
+        <Avatar
+          $size={viewportWidth <= MOBILE ? 'mobile' : 'pc'}
+          $src={userImage}
+        />
         <UserInfoContentsWrapper>
           <UserInfoNicknameBadgeWrapper>
-            <UserInfoNickname>닉네임</UserInfoNickname>
+            <UserInfoNickname>{userName}</UserInfoNickname>
             <UserInfoBadgeWrapper>
-              <Badge
-                $state={'basic'}
-                $size={viewportWidth <= MOBILE ? 'xxs' : 'xs'}
-                $text={'프론트엔드'}
-                style={{ backgroundColor: '#009c4d' }}
-              />
-              <Badge
-                $state={'basic'}
-                $size={viewportWidth <= MOBILE ? 'xxs' : 'xs'}
-                $text={'프론트엔드'}
-                style={{ backgroundColor: '#009c4d' }}
-              />
-              <Badge
-                $state={'basic'}
-                $size={viewportWidth <= MOBILE ? 'xxs' : 'xs'}
-                $text={'프론트엔드'}
-                style={{ backgroundColor: '#009c4d' }}
-              />
+              {tags ? (
+                tags.map((tag, index) => (
+                  <Badge
+                    $state={'basic'}
+                    $size={viewportWidth <= MOBILE ? 'xxs' : 'xs'}
+                    $text={tag}
+                    style={{ backgroundColor: '#009c4d' }}
+                    key={index}
+                  />
+                ))
+              ) : (
+                <NotDataText>관심 분야가 없습니다.</NotDataText>
+              )}
             </UserInfoBadgeWrapper>
           </UserInfoNicknameBadgeWrapper>
           <UserInfoLinkWrapper>
-            <UserInfoLink>
-              <IconWrapper $size={viewportWidth <= MOBILE ? 'xss' : 'xs'}>
-                <IoIosLink />
-              </IconWrapper>
-              <a href="https://github.com/Team-kiwing">
-                https://github.com/Team-kiwing
-              </a>
-            </UserInfoLink>
-            <UserInfoLink>
-              <IconWrapper $size={viewportWidth <= MOBILE ? 'xss' : 'xs'}>
-                <IoIosLink />
-              </IconWrapper>
-              <a href="https://velog.io/@jaehyun_ground/posts">
-                https://velog.io/@jaehyun_ground/posts
-              </a>
-            </UserInfoLink>
-            <UserInfoLink>
-              <IconWrapper $size={viewportWidth <= MOBILE ? 'xss' : 'xs'}>
-                <IoIosLink />
-              </IconWrapper>
-              <a href="https://github.com/Team-kiwing">
-                https://github.com/Team-kiwing
-              </a>
-            </UserInfoLink>
+            {links ? (
+              links.map((link, index) => (
+                <UserInfoLink key={index}>
+                  <IconWrapper $size={viewportWidth <= MOBILE ? 'xss' : 'xs'}>
+                    <IoIosLink />
+                  </IconWrapper>
+                  <a href={link}>{link}</a>
+                </UserInfoLink>
+              ))
+            ) : (
+              <NotDataText>등록된 링크가 없습니다.</NotDataText>
+            )}
           </UserInfoLinkWrapper>
         </UserInfoContentsWrapper>
         <UserInfoIconWrapper>

--- a/src/components/common/UserInfoCard/UserInfoCard.tsx
+++ b/src/components/common/UserInfoCard/UserInfoCard.tsx
@@ -1,0 +1,5 @@
+const UserInfoCard = () => {
+  return <div>유저 인포 카드</div>;
+};
+
+export default UserInfoCard;

--- a/src/components/common/UserInfoCard/UserInfoCard.tsx
+++ b/src/components/common/UserInfoCard/UserInfoCard.tsx
@@ -19,6 +19,16 @@ import {
   UserInfoWrapper,
 } from './UserInfoCard.style';
 
+/**
+ *
+ * @description UserInfo 컴포넌트
+ * @summary 사용법 :
+ * <UserInfoCard />
+ * 데이터 형식이 어떻게 될 지 몰라서, API 명세서가 나온 후 props 작업 진행 할 예정입니다 !
+ * @returns
+ */
+
+// TODO: API 명세서 나오면 데이터 형식에 맞게 props 설정하기
 const UserInfoCard = () => {
   const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
   let timer = null;

--- a/src/components/common/UserInfoCard/UserInfoCard.tsx
+++ b/src/components/common/UserInfoCard/UserInfoCard.tsx
@@ -25,8 +25,21 @@ import { UserInfoCardProps } from './UserInfoCard.type';
  *
  * @description UserInfoCard 컴포넌트
  * @summary 사용법 :
- * <UserInfoCard />
- * 데이터 형식이 어떻게 될 지 몰라서, API 명세서가 나온 후 props 작업 진행 할 예정입니다 !
+ * <UserInfoCard
+      userName="JaehyunGround"
+      tags={['프론트엔드', '백엔드', '네트워크']}
+      links={[
+        'https://github.com/Team-kiwing',
+        'https://velog.io/@jaehyun_ground/posts',
+        'https://github.com/Team-kiwing',
+      ]}
+    />
+ * @summary 데이터 형식이 어떻게 될 지 몰라서, 임시로 구현했고 API 명세서가 나온 후 props 수정 작업 진행하겠습니다 !
+
+ * @param userImage : 선택 | string 타입. 유저의 프로필 사진 src를 받습니다.
+ * @param userName : 필수 | string 타입. 유저의 닉네임을 받습니다.
+ * @param tags : 선택 | string[] 타입. 유저가 선택한 태그들을 배열 형태로 받습니다.
+ * @param links : 선택 | string[] 타입. 유저가 등록한 링크들을 배열 형태로 받습니다.
  * @returns
  */
 

--- a/src/components/common/UserInfoCard/UserInfoCard.tsx
+++ b/src/components/common/UserInfoCard/UserInfoCard.tsx
@@ -10,7 +10,8 @@ import { useTheme } from 'styled-components';
 import { MOBILE } from '@/constants';
 
 import {
-  NotDataText,
+  NoLinks,
+  NoTags,
   UserInfoBadgeWrapper,
   UserInfoContentsWrapper,
   UserInfoIconWrapper,
@@ -99,7 +100,7 @@ const UserInfoCard = ({
                   />
                 ))
               ) : (
-                <NotDataText>관심 분야가 없습니다.</NotDataText>
+                <NoTags>관심 분야가 없습니다.</NoTags>
               )}
             </UserInfoBadgeWrapper>
           </UserInfoNicknameBadgeWrapper>
@@ -119,7 +120,7 @@ const UserInfoCard = ({
                 </UserInfoLink>
               ))
             ) : (
-              <NotDataText>등록된 링크가 없습니다.</NotDataText>
+              <NoLinks>등록된 링크가 없습니다.</NoLinks>
             )}
           </UserInfoLinkWrapper>
         </UserInfoContentsWrapper>

--- a/src/components/common/UserInfoCard/UserInfoCard.tsx
+++ b/src/components/common/UserInfoCard/UserInfoCard.tsx
@@ -110,7 +110,12 @@ const UserInfoCard = ({
                   <IconWrapper $size={viewportWidth <= MOBILE ? 'xss' : 'xs'}>
                     <IoIosLink />
                   </IconWrapper>
-                  <a href={link}>{link}</a>
+                  <a
+                    href={link}
+                    target="_blank"
+                  >
+                    {link}
+                  </a>
                 </UserInfoLink>
               ))
             ) : (

--- a/src/components/common/UserInfoCard/UserInfoCard.tsx
+++ b/src/components/common/UserInfoCard/UserInfoCard.tsx
@@ -21,7 +21,7 @@ import {
 
 /**
  *
- * @description UserInfo 컴포넌트
+ * @description UserInfoCard 컴포넌트
  * @summary 사용법 :
  * <UserInfoCard />
  * 데이터 형식이 어떻게 될 지 몰라서, API 명세서가 나온 후 props 작업 진행 할 예정입니다 !

--- a/src/components/common/UserInfoCard/UserInfoCard.tsx
+++ b/src/components/common/UserInfoCard/UserInfoCard.tsx
@@ -47,8 +47,8 @@ import { UserInfoCardProps } from './UserInfoCard.type';
 const UserInfoCard = ({
   userImage,
   userName,
-  tags,
-  links,
+  tags = [],
+  links = [],
 }: UserInfoCardProps) => {
   const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
   let timer = null;
@@ -83,7 +83,7 @@ const UserInfoCard = ({
           <UserInfoNicknameBadgeWrapper>
             <UserInfoNickname>{userName}</UserInfoNickname>
             <UserInfoBadgeWrapper>
-              {tags ? (
+              {tags.length !== 0 ? (
                 tags.map((tag, index) => (
                   <Badge
                     $state={'basic'}
@@ -99,7 +99,7 @@ const UserInfoCard = ({
             </UserInfoBadgeWrapper>
           </UserInfoNicknameBadgeWrapper>
           <UserInfoLinkWrapper>
-            {links ? (
+            {links.length !== 0 ? (
               links.map((link, index) => (
                 <UserInfoLink key={index}>
                   <IconWrapper $size={viewportWidth <= MOBILE ? 'xss' : 'xs'}>

--- a/src/components/common/UserInfoCard/UserInfoCard.tsx
+++ b/src/components/common/UserInfoCard/UserInfoCard.tsx
@@ -5,6 +5,7 @@ import ShadowBox from '@components/common/ShadowBox/ShadowBox';
 import { useEffect, useState } from 'react';
 import { IoIosLink } from 'react-icons/io';
 import { PiNotePencil, PiSignOut } from 'react-icons/pi';
+import { useTheme } from 'styled-components';
 
 import { MOBILE } from '@/constants';
 
@@ -50,6 +51,8 @@ const UserInfoCard = ({
   tags = [],
   links = [],
 }: UserInfoCardProps) => {
+  const theme = useTheme();
+
   const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
   let timer = null;
 
@@ -89,7 +92,9 @@ const UserInfoCard = ({
                     $state={'basic'}
                     $size={viewportWidth <= MOBILE ? 'xxs' : 'xs'}
                     $text={tag}
-                    style={{ backgroundColor: '#009c4d' }}
+                    style={{
+                      backgroundColor: `${theme.symbol_secondary_color}`,
+                    }}
                     key={index}
                   />
                 ))

--- a/src/components/common/UserInfoCard/UserInfoCard.tsx
+++ b/src/components/common/UserInfoCard/UserInfoCard.tsx
@@ -72,7 +72,7 @@ const UserInfoCard = ({
     <ShadowBox
       width={viewportWidth <= MOBILE ? '90%' : '80%'}
       height={'100%'}
-      style={{ minWidth: '280px', margin: '0 auto' }}
+      style={{ minWidth: '260px', margin: '0 auto' }}
     >
       <UserInfoWrapper>
         <Avatar

--- a/src/components/common/UserInfoCard/UserInfoCard.tsx
+++ b/src/components/common/UserInfoCard/UserInfoCard.tsx
@@ -1,13 +1,13 @@
+import Avatar from '@components/common/Avatar/Avatar';
+import Badge from '@components/common/Badge/Badge';
+import IconWrapper from '@components/common/IconWrapper/IconWrapper';
+import ShadowBox from '@components/common/ShadowBox/ShadowBox';
 import { useEffect, useState } from 'react';
 import { IoIosLink } from 'react-icons/io';
 import { PiNotePencil, PiSignOut } from 'react-icons/pi';
 
 import { MOBILE } from '@/constants';
 
-import Avatar from '../Avatar';
-import Badge from '../Badge';
-import IconWrapper from '../IconWrapper';
-import ShadowBox from '../ShadowBox';
 import {
   NotDataText,
   UserInfoBadgeWrapper,

--- a/src/components/common/UserInfoCard/UserInfoCard.tsx
+++ b/src/components/common/UserInfoCard/UserInfoCard.tsx
@@ -1,5 +1,119 @@
+import { useEffect, useState } from 'react';
+import { IoIosLink } from 'react-icons/io';
+import { PiNotePencil, PiSignOut } from 'react-icons/pi';
+
+import { MOBILE } from '@/constants';
+
+import Avatar from '../Avatar';
+import Badge from '../Badge';
+import IconWrapper from '../IconWrapper';
+import ShadowBox from '../ShadowBox';
+import {
+  UserInfoBadgeWrapper,
+  UserInfoContentsWrapper,
+  UserInfoIconWrapper,
+  UserInfoLink,
+  UserInfoLinkWrapper,
+  UserInfoNickname,
+  UserInfoNicknameBadgeWrapper,
+  UserInfoWrapper,
+} from './UserInfoCard.style';
+
 const UserInfoCard = () => {
-  return <div>유저 인포 카드</div>;
+  const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
+  let timer = null;
+
+  useEffect(() => {
+    const resizeViewportWidth = () => {
+      clearTimeout(timer!);
+      timer = setTimeout(() => {
+        setViewportWidth(window.innerWidth);
+      }, 200);
+    };
+
+    window.addEventListener('resize', resizeViewportWidth);
+
+    return () => {
+      window.removeEventListener('resize', resizeViewportWidth);
+    };
+  }, []);
+
+  return (
+    <ShadowBox
+      width={viewportWidth <= MOBILE ? '90%' : '80%'}
+      height={'100%'}
+      style={{ minWidth: '280px', margin: '0 auto' }}
+    >
+      <UserInfoWrapper>
+        <Avatar $size={viewportWidth <= MOBILE ? 'mobile' : 'pc'} />
+        <UserInfoContentsWrapper>
+          <UserInfoNicknameBadgeWrapper>
+            <UserInfoNickname>닉네임</UserInfoNickname>
+            <UserInfoBadgeWrapper>
+              <Badge
+                $state={'basic'}
+                $size={viewportWidth <= MOBILE ? 'xxs' : 'xs'}
+                $text={'프론트엔드'}
+                style={{ backgroundColor: '#009c4d' }}
+              />
+              <Badge
+                $state={'basic'}
+                $size={viewportWidth <= MOBILE ? 'xxs' : 'xs'}
+                $text={'프론트엔드'}
+                style={{ backgroundColor: '#009c4d' }}
+              />
+              <Badge
+                $state={'basic'}
+                $size={viewportWidth <= MOBILE ? 'xxs' : 'xs'}
+                $text={'프론트엔드'}
+                style={{ backgroundColor: '#009c4d' }}
+              />
+            </UserInfoBadgeWrapper>
+          </UserInfoNicknameBadgeWrapper>
+          <UserInfoLinkWrapper>
+            <UserInfoLink>
+              <IconWrapper $size={viewportWidth <= MOBILE ? 'xss' : 'xs'}>
+                <IoIosLink />
+              </IconWrapper>
+              <a href="https://github.com/Team-kiwing">
+                https://github.com/Team-kiwing
+              </a>
+            </UserInfoLink>
+            <UserInfoLink>
+              <IconWrapper $size={viewportWidth <= MOBILE ? 'xss' : 'xs'}>
+                <IoIosLink />
+              </IconWrapper>
+              <a href="https://velog.io/@jaehyun_ground/posts">
+                https://velog.io/@jaehyun_ground/posts
+              </a>
+            </UserInfoLink>
+            <UserInfoLink>
+              <IconWrapper $size={viewportWidth <= MOBILE ? 'xss' : 'xs'}>
+                <IoIosLink />
+              </IconWrapper>
+              <a href="https://github.com/Team-kiwing">
+                https://github.com/Team-kiwing
+              </a>
+            </UserInfoLink>
+          </UserInfoLinkWrapper>
+        </UserInfoContentsWrapper>
+        <UserInfoIconWrapper>
+          <IconWrapper
+            $size={viewportWidth <= MOBILE ? 'xs' : 's'}
+            onClick={() => alert('회원 정보 수정 모달 띄우는 작업 해야함 !')}
+          >
+            <PiNotePencil />
+          </IconWrapper>
+          <IconWrapper
+            $size={viewportWidth <= MOBILE ? 'xs' : 's'}
+            onClick={() => alert('로그아웃 작업 해야함 !')}
+          >
+            <PiSignOut />
+          </IconWrapper>
+        </UserInfoIconWrapper>
+      </UserInfoWrapper>
+    </ShadowBox>
+  );
 };
 
 export default UserInfoCard;

--- a/src/components/common/UserInfoCard/UserInfoCard.type.ts
+++ b/src/components/common/UserInfoCard/UserInfoCard.type.ts
@@ -1,0 +1,6 @@
+export interface UserInfoCardProps {
+  userImage?: string;
+  userName: string;
+  tags?: string[];
+  links?: string[];
+}

--- a/src/components/common/UserInfoCard/index.ts
+++ b/src/components/common/UserInfoCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from './UserInfoCard';


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용

- 유저 프로필 역할을 하는 UserInfoCard 컴포넌트를 구현했습니다.

# 📷스크린샷(필요 시)

https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/9a3c2649-aace-4b23-844d-a84cea8a224e

다크모드는 용량 문제 로 인해 아래 사진으로 대체합니다 !!
![스크린샷 2024-02-21 오후 11 07 20](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/a3d814c8-c97c-4922-b34f-1862315916ba)

# 🔥사용 방법

### dummy.json

```json
[
  {
    "message": "string",
    "data": {
      "id": 0,
      "nickname": "JaehyunGround",
      "profileImage": "123123123123123",
      "email": "gothddlek2603@gmail.com",
      "tags": ["프론트엔드", "디자인", "백엔드"],
      "links": [
        "https://github.com/Team-kiwing",
        "https://velog.io/@jaehyun_ground/postshttps://velog.io/@jaehyun_ground/postshttps://velog.io/@jaehyun_ground/postshttps://velog.io/@jaehyun_ground/postshttps://velog.io/@jaehyun_ground/postshttps://velog.io/@jaehyun_ground/postshttps://velog.io/@jaehyun_ground/postshttps://velog.io/@jaehyun_ground/postshttps://velog.io/@jaehyun_ground/posts",
        "https://github.com/JaeHyunGround"
      ],
      "provider": "GOOGLE"
    }
  }
]

```

### handler.ts

```typescript
import { http, HttpResponse } from 'msw';

import myInfo from './dummy.json';

const handlers = [
  http.get('/member/me', async () => {
    await sleep(200);
    return HttpResponse.json(myInfo);
  }),
];

async function sleep(timeout: number) {
  return new Promise((resolve) => {
    setTimeout(resolve, timeout);
  });
}

export default handlers;
```

### TestPage.tsx (사용하는 곳)

```typescript

import { useEffect, useState } from 'react';

import UserInfoCard from '@/components/common/UserInfoCard';

interface myInfoList {
  id: number;
  nickname: string;
  profileImage: string;
  email: string;
  tags: string[];
  links: string[];
  provider: string;
}

const TestPage = () => {
  const [myInfo, setMyInfo] = useState<myInfoList>();
  const [isLoading, setIsLoading] = useState<boolean>(false);

  const fetchMyInfo = async () => {
    setIsLoading(true);
    await fetch('/member/me')
      .then((res) => res.json())
      .then((data) => setMyInfo(data[0].data))
      .catch(() =>
        alert(
          '내 정보를 불러오는 과정에서 에러가 발생했습니다. 잠시 후 다시 접속해주세요.'
        )
      );
    setIsLoading(false);
  };

  useEffect(() => {
    fetchMyInfo();
  }, []);

  return (
    <>
      {isLoading ? (
        <div>스피너를 만들까요?</div>
      ) : (
        myInfo && (
          <UserInfoCard
            userImage={myInfo.profileImage}
            userName={myInfo.nickname}
            tags={myInfo.tags}
            links={myInfo.links}
          />
        )
      )}
    </>
  );
};

export default TestPage;


```

- `UserInfoCard` 컴포넌트에서 필수 props는 `userName`입니다.
  - `userName`은 string 타입이며, 유저의 닉네임을 받습니다.

- `UserInfoCard` 컴포넌트에서 선택 props는 `userImage`, `tags`, `links`입니다.
  - `userImage`는 string 타입이며, 유저의 프로필 이미지 경로를 받습니다.
  - `tags`는 string[] 타입이며, 유저의 관심 분야 태그들을 배열로 받습니다.
  - `links`는 string[] 타입이며, 유저가 등록한 링크들을 배열로 받습니다.

### `tags` 를 생략하면 아래 사진과 같습니다.
![스크린샷 2024-02-21 오후 11 24 35](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/be13e8c9-bf72-4d3b-8345-e852c1482aca)
![스크린샷 2024-02-21 오후 11 25 57](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/c2d3c8f4-b139-4cb8-b00b-e940d959a1eb)

### `links`를 생략하면 아래 사진과 같습니다.
![스크린샷 2024-02-21 오후 11 25 10](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/e76bbf29-a2c2-47ed-b5c4-486f73d1528a)
![스크린샷 2024-02-21 오후 11 25 40](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/25e5929d-a645-4ed9-a34d-9db500d9353c)

### `tags` , `links` 둘 다 생략하면 아래 사진과 같습니다.

![스크린샷 2024-02-21 오후 11 28 12](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/430d303f-e3d9-4c47-9336-ee9fe604a7fc)
![스크린샷 2024-02-21 오후 11 27 09](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/354e516b-cd7d-4d5e-98a9-2141c6ff01e6)


# ✨PR Point

- props는 API 명세서가 나온 후 데이터 응답 형태를 확인하여 수정이 필요하면 수정 작업을 할 예정입니다.
- 컴포넌트 오른쪽 아이콘을 눌렀을 때의 기능인 `정보 수정 모달 띄우기`, `로그아웃 하기`는 `v1.1.0`에 작업할 예정입니다.

- 컴포넌트 내에서 **`가운데 정렬을 합니다.`**
  - 사용하는 곳 전부 가운데 정렬된 형태로 쓰이고 있어서 컴포넌트 내에서 처리했습니다.
  - **가운데 정렬 옵션을 사용하는 곳에서 설정할 수 있도록 props를 만들어야 할까요 ? 아니면 컴포넌트 자체에서 가운데 정렬을 처리해도 괜찮을까요 ?**

~~- 갤럭시 폴드 환경에서는 `UserInfoCard 컴포넌트 좌우 여백이 존재하지 않습니다.`~~
  ~~- 좌우 여백을 두려고 하니 디자인이 찌그러져서.... 불가피하게 폴드 환경에서는 UserInfoCard 컴포넌트가 너비 영역을 다 차지 합니다...~~
=> 갤럭시 폴드 환경에서도 좌우 여백이 생기도록 수정했습니다 !

- resize 이벤트에 쓰로틀링을 걸어주었기에 컴포넌트가 반응형으로 확확 바뀌는 것이 아닌 resize 이벤트가 끝난 후 0.3초 뒤에 반영됩니다.
  - 이는 화면 너비를 조절할 때마다 resize 이벤트가 발생함에 따라 생기는 성능 문제를 해결하기 위해 `setTimeOut`을 이용한 쓰로틀링 기법을 적용 해두었습니다.
  - **반응형으로 확확 바뀌게 하는 것이 좋을까요 ?  아니면 성능을 고려하여 쓰로틀링을 걸어주는 것이 좋을까요?**

- 불닭맛 피드백 및 의견 환영입니다 !!

---

# 24.02.25 수정사항

- 갤럭시 폴드 환경에서도 컴포넌트의 좌우 여백이 생길 수 있도록 수정했습니다.

- 사용자가 등록한 링크가 길 경우, 레이아웃이 깨지는 문제가 있었습니다.
<img width="1402" alt="스크린샷 2024-02-25 오후 5 37 48" src="https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/9493cf42-67f9-4521-a4eb-ec81a92057fc">

따라서 문자가 길어질 때 `...` 처리 해주는 것 대신 문자가 길어질 수록 `줄 바꿈이 되게 구현했습니다.`
 
<img width="1396" alt="스크린샷 2024-02-25 오후 5 39 01" src="https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/442f9678-a0f5-4887-8775-97719a1ea5e4">

다만 모바일 환경에서는 안 이뻐보인다는 것이 단점인데 이를 해결할 수 있는 방법은 어떤 것이 있을까요...?
<img width="483" alt="스크린샷 2024-02-25 오후 5 35 03" src="https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/da8dae59-fa40-4a48-8467-b07ace536356">

# 24.02.26 수정사항
- 사용자가 기입한 링크가 길 경우, 레이아웃이 깨지는 문제를 해결했습니다.
  - 기존에 `...` 으로 처리했다가 `줄바꿈` 형식으로 수정을 하였는데, 다시 텍스트가 길어지면 `...` 처리되도록 레이아웃 문제를 해결했습니다.
  - 
https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/4710235e-be3c-4a23-a809-1346ffe88c78

- MSW를 도입했습니다.
  - 관련 코드는 PR의 `사용 방법`에 기입했습니다.
