### PR TITLE
[#63] Badge 컴포넌트 구현 v1.2.0

### DIFF
--- a/src/components/common/Badge/Badge.style.ts
+++ b/src/components/common/Badge/Badge.style.ts
@@ -30,6 +30,11 @@ const stateStyles = {
     background-color: ${({ theme }) => theme.hotBadge_background_color};
     color: ${({ theme }) => theme.hotBadge_color};
   `,
+  subscribed: css`
+    font-weight: ${FONT_SEMI_BOLD};
+    background-color: ${({ theme }) => theme.subscribed_background_color};
+    color: ${({ theme }) => theme.subscribed_color};
+  `,
 };
 
 export const StyledBadge = styled.span<PropsStyledBadge>`

--- a/src/components/common/Badge/Badge.style.ts
+++ b/src/components/common/Badge/Badge.style.ts
@@ -27,7 +27,7 @@ const stateStyles = {
     color: ${({ theme }) => theme.hotBadge_color};
   `,
   hashTag: css`
-    background-color: white;
+    background-color: transparent;
     color: ${({ theme }) => theme.gray_300};
   `,
   subscribedTag: css`

--- a/src/components/common/Badge/Badge.style.ts
+++ b/src/components/common/Badge/Badge.style.ts
@@ -6,7 +6,7 @@ import { PropsStyledBadge } from './Badge.type';
 
 const sizeMapping = {
   xxs: '0.8rem',
-  xs: '1rem',
+  xs: '1.1rem',
   s: '1.4rem',
   m: '1.8rem',
   l: '2.2rem',
@@ -21,16 +21,19 @@ const stateStyles = {
     background-color: ${({ theme }) => theme.symbol_color};
     color: white;
   `,
-  hashTag: css`
-    background-color: white;
-    color: ${({ theme }) => theme.gray_300};
-  `,
   hot: css`
     font-weight: ${FONT_SEMI_BOLD};
     background-color: ${({ theme }) => theme.hotBadge_background_color};
     color: ${({ theme }) => theme.hotBadge_color};
   `,
-  subscribed: css`
+  hashTag: css`
+    background-color: white;
+    color: ${({ theme }) => theme.gray_300};
+  `,
+  subscribedTag: css`
+    display: flex;
+    gap: 0.1rem;
+    align-items: center;
     font-weight: ${FONT_SEMI_BOLD};
     background-color: ${({ theme }) => theme.subscribed_background_color};
     color: ${({ theme }) => theme.subscribed_color};

--- a/src/components/common/Badge/Badge.style.ts
+++ b/src/components/common/Badge/Badge.style.ts
@@ -60,9 +60,4 @@ export const StyledBadge = styled.span<PropsStyledBadge>`
       ${({ $isHover }) => $isHover && stateStyles.focus}
     }
   }
-  @media screen and (max-width: 280px) {
-    padding: 0.75rem 1.25rem;
-    width: fit-content;
-    font-size: 1rem;
-  }
 `;

--- a/src/components/common/Badge/Badge.style.ts
+++ b/src/components/common/Badge/Badge.style.ts
@@ -29,6 +29,7 @@ const stateStyles = {
   hashTag: css`
     background-color: transparent;
     color: ${({ theme }) => theme.gray_300};
+    cursor: default;
   `,
   subscribedTag: css`
     display: flex;
@@ -37,6 +38,7 @@ const stateStyles = {
     font-weight: ${FONT_SEMI_BOLD};
     background-color: ${({ theme }) => theme.subscribed_background_color};
     color: ${({ theme }) => theme.subscribed_color};
+    cursor: default;
   `,
 };
 

--- a/src/components/common/Badge/Badge.tsx
+++ b/src/components/common/Badge/Badge.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { BsBookmarksFill } from 'react-icons/bs';
 
 import IconWrapper from '../IconWrapper/IconWrapper';
@@ -35,13 +34,13 @@ const Badge = ({
   $subscribedCount,
   ...props
 }: PropsBadge) => {
-  const displayText = useMemo(() => {
+  const displayText = () => {
     if ($subscribedCount !== undefined && $state === 'subscribedTag') {
       return (
         <>
           <IconWrapper
             style={{ cursor: 'default' }}
-            $size={1.5}
+            $size={$size === 'xs' ? 1.5 : 1.8}
           >
             <BsBookmarksFill />
           </IconWrapper>
@@ -56,7 +55,7 @@ const Badge = ({
       return `#${$text}`;
     }
     return $text;
-  }, [$text, $state, $subscribedCount]);
+  };
 
   return (
     <>
@@ -67,7 +66,7 @@ const Badge = ({
         $margin={$margin}
         {...props}
       >
-        {displayText}
+        {displayText()}
       </StyledBadge>
     </>
   );

--- a/src/components/common/Badge/Badge.tsx
+++ b/src/components/common/Badge/Badge.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { BsBookmarkStarFill } from 'react-icons/bs';
+import { BsBookmarksFill } from 'react-icons/bs';
 
 import IconWrapper from '../IconWrapper/IconWrapper';
 import { StyledBadge } from './Badge.style';
@@ -39,8 +39,11 @@ const Badge = ({
     if ($subscribedCount !== undefined && $state === 'subscribedTag') {
       return (
         <>
-          <IconWrapper $size={1.2}>
-            <BsBookmarkStarFill />
+          <IconWrapper
+            style={{ cursor: 'default' }}
+            $size={1.5}
+          >
+            <BsBookmarksFill />
           </IconWrapper>
           <span>
             {$subscribedCount < 1000

--- a/src/components/common/Badge/Badge.tsx
+++ b/src/components/common/Badge/Badge.tsx
@@ -1,6 +1,8 @@
+import { BsBookmarkStarFill } from 'react-icons/bs';
+
+import IconWrapper from '../IconWrapper/IconWrapper';
 import { StyledBadge } from './Badge.style';
 import { PropsBadge } from './Badge.type';
-
 /**
  * @summary 사용법 <Badge
       $size={'m'}
@@ -9,12 +11,17 @@ import { PropsBadge } from './Badge.type';
       $isHover={true}
       $text={'백엔드'}
     />
+        <Badge
+          $size={'m'}
+          $state="subscribedTag"
+          $subscribedCount={11150}
+        />
  * @description 공통 Badge 컴포넌트
- * @param $size font-size의 크기
- * @param $state basic, focus, hashTag, hot이 있으면 background-color와 color의 색깔을 지정합니다.
- * @param $margin margin 값을 받습니다.
- * @param $hover true false에 따라 hover가 적용됩니다.
- * @param $text 뱃지안에 들어간 text값 입니다.
+ * @param $size 필수) font-size의 크기입니다 'xxs, xs, s, m, l' 타입과 number타입이 있습니다.
+ * @param $state 필수) basic, focus, hashTag, hot이 있으면 background-color와 color의 색깔을 지정합니다.
+ * @param $margin 선택) margin 값을 받습니다.
+ * @param $hover 선택) true false에 따라 hover가 적용됩니다.
+ * @param $text 선택) 뱃지안에 들어가는 값입니다. (ReactNode타입 입니다.)
  * @returns
  */
 
@@ -29,26 +36,35 @@ const Badge = ({
 }: PropsBadge) => {
   let displayText = $text;
 
-  if ($subscribedCount !== undefined && $state === 'subscribed') {
-    if ($subscribedCount < 100) {
-      displayText = `${$subscribedCount}`;
-    } else {
-      displayText = `${($subscribedCount / 1000).toFixed(1)}K+`;
-    }
+  if ($subscribedCount !== undefined && $state === 'subscribedTag') {
+    displayText = (
+      <>
+        <IconWrapper $size={1.2}>
+          <BsBookmarkStarFill />
+        </IconWrapper>
+        <span>
+          {$subscribedCount < 1000
+            ? $subscribedCount
+            : `${Math.floor($subscribedCount / 100) / 10}K+`}
+        </span>
+      </>
+    );
   } else if ($state === 'hashTag') {
     displayText = `#${$text}`;
   }
 
   return (
-    <StyledBadge
-      $size={$size}
-      $state={$state}
-      $isHover={$isHover}
-      $margin={$margin}
-      {...props}
-    >
-      {displayText}
-    </StyledBadge>
+    <>
+      <StyledBadge
+        $size={$size}
+        $state={$state}
+        $isHover={$isHover}
+        $margin={$margin}
+        {...props}
+      >
+        {displayText}
+      </StyledBadge>
+    </>
   );
 };
 

--- a/src/components/common/Badge/Badge.tsx
+++ b/src/components/common/Badge/Badge.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { BsBookmarkStarFill } from 'react-icons/bs';
 
 import IconWrapper from '../IconWrapper/IconWrapper';
@@ -34,24 +35,25 @@ const Badge = ({
   $subscribedCount,
   ...props
 }: PropsBadge) => {
-  let displayText = $text;
-
-  if ($subscribedCount !== undefined && $state === 'subscribedTag') {
-    displayText = (
-      <>
-        <IconWrapper $size={1.2}>
-          <BsBookmarkStarFill />
-        </IconWrapper>
-        <span>
-          {$subscribedCount < 1000
-            ? $subscribedCount
-            : `${Math.floor($subscribedCount / 100) / 10}K+`}
-        </span>
-      </>
-    );
-  } else if ($state === 'hashTag') {
-    displayText = `#${$text}`;
-  }
+  const displayText = useMemo(() => {
+    if ($subscribedCount !== undefined && $state === 'subscribedTag') {
+      return (
+        <>
+          <IconWrapper $size={1.2}>
+            <BsBookmarkStarFill />
+          </IconWrapper>
+          <span>
+            {$subscribedCount < 1000
+              ? $subscribedCount
+              : `${Math.floor($subscribedCount / 100) / 10}K+`}
+          </span>
+        </>
+      );
+    } else if ($state === 'hashTag') {
+      return `#${$text}`;
+    }
+    return $text;
+  }, [$text, $state, $subscribedCount]);
 
   return (
     <>

--- a/src/components/common/Badge/Badge.tsx
+++ b/src/components/common/Badge/Badge.tsx
@@ -24,8 +24,21 @@ const Badge = ({
   $size,
   $text,
   $margin,
+  $subscribedCount,
   ...props
 }: PropsBadge) => {
+  let displayText = $text;
+
+  if ($subscribedCount !== undefined && $state === 'subscribed') {
+    if ($subscribedCount < 100) {
+      displayText = `${$subscribedCount}`;
+    } else {
+      displayText = `${($subscribedCount / 1000).toFixed(1)}K+`;
+    }
+  } else if ($state === 'hashTag') {
+    displayText = `#${$text}`;
+  }
+
   return (
     <StyledBadge
       $size={$size}
@@ -34,7 +47,7 @@ const Badge = ({
       $margin={$margin}
       {...props}
     >
-      {$state === 'hashTag' ? `#${$text}` : $text}
+      {displayText}
     </StyledBadge>
   );
 };

--- a/src/components/common/Badge/Badge.type.ts
+++ b/src/components/common/Badge/Badge.type.ts
@@ -1,7 +1,9 @@
+import { ReactNode } from 'react';
+
 export interface PropsBadge extends React.HTMLAttributes<HTMLSpanElement> {
-  $state: 'basic' | 'focus' | 'hashTag' | 'hot' | 'subscribed';
+  $state: 'basic' | 'focus' | 'hashTag' | 'hot' | 'subscribedTag';
   $size: 'xxs' | 'xs' | 's' | 'm' | 'l' | number;
-  $text?: string;
+  $text?: ReactNode;
   $isHover?: boolean;
   $margin?: string;
   $subscribedCount?: number;

--- a/src/components/common/Badge/Badge.type.ts
+++ b/src/components/common/Badge/Badge.type.ts
@@ -1,9 +1,10 @@
 export interface PropsBadge extends React.HTMLAttributes<HTMLSpanElement> {
-  $state: 'basic' | 'focus' | 'hashTag' | 'hot';
+  $state: 'basic' | 'focus' | 'hashTag' | 'hot' | 'subscribed';
   $size: 'xxs' | 'xs' | 's' | 'm' | 'l' | number;
-  $text: string;
+  $text?: string;
   $isHover?: boolean;
   $margin?: string;
+  $subscribedCount?: number;
 }
 
 export type PropsStyledBadge = Omit<PropsBadge, '$text'>;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -10,6 +10,8 @@ export const lightTheme: object = {
 
   hotBadge_background_color: ' #f7cece',
   hotBadge_color: '#f84c4c',
+  subscribed_background_color: '#FFE500',
+  subscribed_color: '#E3A400',
 
   gray_600: '#565656',
   gray_500: '#5E5E5E',

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -36,6 +36,8 @@ export const darkTheme: object = {
 
   hotBadge_background_color: ' #f7cece',
   hotBadge_color: '#f84c4c',
+  subscribed_background_color: '#FFE500',
+  subscribed_color: '#E3A400',
 
   // 사용성 조사 필요, PR시에 명시해주기 혹은 사전에 논의해주기
   gray_600: '#565656',


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용
공통 컴포넌트인 뱃지컴포넌트에 스크랩숫자를 나타내는 뱃지스타일을 추가했습니다.
# 📷스크린샷(필요 시)
<img width="263" alt="image" src="https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/81172451/2f27c017-5c4c-4d7e-9eab-bd22b6af7377">

# ✨PR Point
- 1000개 미만은 숫자로 보이게 해두었고 그 이상부터는 K+를 붙이도록 구현해두었습니다.
- 기존의 `$text` props는 `string` 타입이였는데 이번에 `ReactNode`으로 변경하였습니다.
- 전역 테마에 스크랩 뱃지 색상을 추가했습니다.
```js
subscribed_background_color: '#FFE500',
subscribed_color: '#E3A400',
```
### 테스트코드

```js
import Badge from '@/components/common/Badge';

const TestPage = () => {
  return (
    <>
      <Badge
        $size={'xs'}
        $state="subscribedTag"
        $subscribedCount={2852}
      />
      <Badge
        $size={'xs'}
        $state="subscribedTag"
        $subscribedCount={1}
      />
      <Badge
        $size={'xs'}
        $state="subscribedTag"
        $subscribedCount={45}
      />
      <Badge
        style={{ padding: '0.5rem 1.3rem', fontSize: '1.1rem' }}
        $size={'xs'}
        $state="subscribedTag"
        $subscribedCount={1200}
      />
      <Badge
        $size={'s'}
        $state="subscribedTag"
        $subscribedCount={990}
      />
      <Badge
        $size={'xs'}
        $state="subscribedTag"
        $subscribedCount={1000}
      />
    </>
  );
};

export default TestPage;
```