### PR TITLE
 [#83] SharedBundleCard 컴포넌트 구현 v1.0.0

### DIFF
--- a/src/components/SharedBundleCard/SharedBundleCard.style.ts
+++ b/src/components/SharedBundleCard/SharedBundleCard.style.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { MOBILE, MOBILE_MIN } from '@/constants';
+import { FONT_SEMI_BOLD, MOBILE, MOBILE_MIN } from '@/constants';
 
 export const SharedBundleCardWrapper = styled.div`
   width: 90%;
@@ -13,6 +13,7 @@ export const SharedBundleCardWrapper = styled.div`
 export const BundleTitle = styled.div`
   font-size: 2rem;
   padding: 2rem;
+  font-weight: ${FONT_SEMI_BOLD - 50};
   width: 70%;
   text-align: center;
   color: ${({ theme }) => theme.secondary_color};

--- a/src/components/SharedBundleCard/SharedBundleCard.style.ts
+++ b/src/components/SharedBundleCard/SharedBundleCard.style.ts
@@ -6,22 +6,25 @@ export const SharedBundleCardWrapper = styled.div`
   width: 90%;
   max-width: 80rem;
   min-width: 28rem;
-  height: 7rem;
   @media screen and (max-width: ${MOBILE}px) {
-    height: 5rem;
   }
 `;
 
 export const BundleTitle = styled.div`
   font-size: 2rem;
+  padding: 2rem;
+  width: 70%;
+  text-align: center;
   color: ${({ theme }) => theme.secondary_color};
 
   @media screen and (max-width: ${MOBILE}px) {
     font-size: 1.6rem;
+    padding: 1.5rem;
   }
 
   @media screen and (max-width: ${MOBILE_MIN}px) {
     font-size: 1.4rem;
+    padding: 1rem;
   }
 `;
 
@@ -30,6 +33,6 @@ export const ClickContent = styled.div`
   align-items: center;
   position: absolute;
   right: 0;
-  margin-right: 1rem;
+  margin: 0 1rem;
   gap: 1rem;
 `;

--- a/src/components/SharedBundleCard/SharedBundleCard.style.ts
+++ b/src/components/SharedBundleCard/SharedBundleCard.style.ts
@@ -1,0 +1,35 @@
+import styled from 'styled-components';
+
+import { MOBILE, MOBILE_MIN } from '@/constants';
+
+export const SharedBundleCardWrapper = styled.div`
+  width: 90%;
+  max-width: 80rem;
+  min-width: 28rem;
+  height: 7rem;
+  @media screen and (max-width: ${MOBILE}px) {
+    height: 5rem;
+  }
+`;
+
+export const BundleTitle = styled.div`
+  font-size: 2rem;
+  color: ${({ theme }) => theme.secondary_color};
+
+  @media screen and (max-width: ${MOBILE}px) {
+    font-size: 1.6rem;
+  }
+
+  @media screen and (max-width: ${MOBILE_MIN}px) {
+    font-size: 1.4rem;
+  }
+`;
+
+export const ClickContent = styled.div`
+  display: flex;
+  align-items: center;
+  position: absolute;
+  right: 0;
+  margin-right: 1rem;
+  gap: 1rem;
+`;

--- a/src/components/SharedBundleCard/SharedBundleCard.tsx
+++ b/src/components/SharedBundleCard/SharedBundleCard.tsx
@@ -1,5 +1,98 @@
-const SharedBundleCard = () => {
-  return <></>;
+import { useEffect, useState } from 'react';
+import { RiFileCopyLine, RiShareLine } from 'react-icons/ri';
+import { useTheme } from 'styled-components';
+
+import CircleButton from '@/components/common/CircleButton';
+import IconWrapper from '@/components/common/IconWrapper';
+import ShadowBox from '@/components/common/ShadowBox';
+import { MOBILE } from '@/constants';
+
+import {
+  BundleTitle,
+  ClickContent,
+  SharedBundleCardWrapper,
+} from './SharedBundleCard.style';
+import { SharedBundleCardProps } from './SharedBundleCard.type';
+
+/**
+ * @summary 사용법   <SharedBundleCard bundleName={'데브코스 면접리스트'} />
+ * @description 공유된 질문꾸러미에 쓰이는 Card입니다.
+ * @param bundleName 필수) 질문꾸러미의 이름입니다. (string 타입입니다.)
+ * @returns
+ */
+
+const SharedBundleCard = ({ bundleName, ...props }: SharedBundleCardProps) => {
+  const theme = useTheme();
+  const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
+  let timer = null;
+
+  useEffect(() => {
+    const resizeViewportWidth = () => {
+      clearTimeout(timer!);
+      timer = setTimeout(() => {
+        setViewportWidth(window.innerWidth);
+      }, 200);
+    };
+
+    window.addEventListener('resize', resizeViewportWidth);
+
+    return () => {
+      window.removeEventListener('resize', resizeViewportWidth);
+    };
+  }, []);
+  return (
+    <>
+      <SharedBundleCardWrapper {...props}>
+        <ShadowBox
+          style={{
+            position: 'relative',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+          isActive={true}
+          width="100%"
+          height="100%"
+        >
+          <BundleTitle>{bundleName}</BundleTitle>
+          {viewportWidth > MOBILE ? (
+            <ClickContent>
+              <CircleButton
+                isBackgroundWhite={true}
+                onClick={() => {
+                  console.log('질문리스트 복사');
+                }}
+              />
+              <IconWrapper
+                $fillColor={theme.secondary_color}
+                $size={'m'}
+                $hoverIconColor={theme.symbol_secondary_color}
+                onClick={() => {
+                  console.log('링크 복사!');
+                }}
+              >
+                <RiFileCopyLine />
+              </IconWrapper>
+            </ClickContent>
+          ) : (
+            <ClickContent>
+              <IconWrapper
+                $fillColor={theme.secondary_color}
+                $size={'s'}
+                $hoverIconColor={theme.symbol_secondary_color}
+                onClick={() => {
+                  console.log('드롭다운 !');
+                }}
+              >
+                <RiShareLine />
+              </IconWrapper>
+            </ClickContent>
+          )}
+        </ShadowBox>
+      </SharedBundleCardWrapper>
+    </>
+  );
 };
 
 export default SharedBundleCard;

--- a/src/components/SharedBundleCard/SharedBundleCard.tsx
+++ b/src/components/SharedBundleCard/SharedBundleCard.tsx
@@ -1,11 +1,10 @@
-import { useEffect, useState } from 'react';
 import { RiFileCopyLine, RiShareLine } from 'react-icons/ri';
 import { useTheme } from 'styled-components';
 
 import CircleButton from '@/components/common/CircleButton';
 import IconWrapper from '@/components/common/IconWrapper';
 import ShadowBox from '@/components/common/ShadowBox';
-import { MOBILE } from '@/constants';
+import useResize from '@/hooks/useResize';
 
 import {
   BundleTitle,
@@ -23,23 +22,8 @@ import { SharedBundleCardProps } from './SharedBundleCard.type';
 
 const SharedBundleCard = ({ bundleName, ...props }: SharedBundleCardProps) => {
   const theme = useTheme();
-  const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
-  let timer = null;
+  const { isMobileSize } = useResize();
 
-  useEffect(() => {
-    const resizeViewportWidth = () => {
-      clearTimeout(timer!);
-      timer = setTimeout(() => {
-        setViewportWidth(window.innerWidth);
-      }, 200);
-    };
-
-    window.addEventListener('resize', resizeViewportWidth);
-
-    return () => {
-      window.removeEventListener('resize', resizeViewportWidth);
-    };
-  }, []);
   return (
     <>
       <SharedBundleCardWrapper {...props}>
@@ -55,7 +39,7 @@ const SharedBundleCard = ({ bundleName, ...props }: SharedBundleCardProps) => {
           height="100%"
         >
           <BundleTitle>{bundleName}</BundleTitle>
-          {viewportWidth > MOBILE ? (
+          {!isMobileSize ? (
             <ClickContent>
               <CircleButton
                 isBackgroundWhite={true}

--- a/src/components/SharedBundleCard/SharedBundleCard.tsx
+++ b/src/components/SharedBundleCard/SharedBundleCard.tsx
@@ -1,4 +1,5 @@
 import { RiFileCopyLine, RiShareLine } from 'react-icons/ri';
+import { useLocation } from 'react-router-dom';
 import { useTheme } from 'styled-components';
 
 import CircleButton from '@/components/common/CircleButton';
@@ -23,7 +24,18 @@ import { SharedBundleCardProps } from './SharedBundleCard.type';
 const SharedBundleCard = ({ bundleName, ...props }: SharedBundleCardProps) => {
   const theme = useTheme();
   const { isMobileSize } = useResize();
+  const location = useLocation();
 
+  const currentURL = location.pathname;
+
+  const handleCopyClipBoard = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      alert('클립보드에 링크가 복사되었습니다.');
+    } catch (err) {
+      console.log(err);
+    }
+  };
   return (
     <>
       <SharedBundleCardWrapper {...props}>
@@ -52,7 +64,7 @@ const SharedBundleCard = ({ bundleName, ...props }: SharedBundleCardProps) => {
                 $size={'m'}
                 $hoverIconColor={theme.symbol_secondary_color}
                 onClick={() => {
-                  console.log('링크 복사!');
+                  handleCopyClipBoard(currentURL);
                 }}
               >
                 <RiFileCopyLine />

--- a/src/components/SharedBundleCard/SharedBundleCard.tsx
+++ b/src/components/SharedBundleCard/SharedBundleCard.tsx
@@ -47,7 +47,6 @@ const SharedBundleCard = ({ bundleName, ...props }: SharedBundleCardProps) => {
           style={{
             position: 'relative',
             display: 'flex',
-            flexDirection: 'column',
             justifyContent: 'center',
             alignItems: 'center',
           }}

--- a/src/components/SharedBundleCard/SharedBundleCard.tsx
+++ b/src/components/SharedBundleCard/SharedBundleCard.tsx
@@ -1,0 +1,5 @@
+const SharedBundleCard = () => {
+  return <></>;
+};
+
+export default SharedBundleCard;

--- a/src/components/SharedBundleCard/SharedBundleCard.type.ts
+++ b/src/components/SharedBundleCard/SharedBundleCard.type.ts
@@ -1,0 +1,4 @@
+export interface SharedBundleCardProps
+  extends React.HTMLAttributes<HTMLSpanElement> {
+  bundleName: string;
+}

--- a/src/components/SharedBundleCard/index.ts
+++ b/src/components/SharedBundleCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SharedBundleCard';


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용
공유된 질문꾸러미 Card 컴포넌트입니다. 
# 📷스크린샷(필요 시)
### 웹 UI
<img width="854" alt="image" src="https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/81172451/acd7f3d9-1834-40d6-9ed1-a03f25e04711">

### 모바일 UI
<img width="478" alt="image" src="https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/81172451/5d09d6cc-16cf-483e-bef6-805a935a2de1">

# ✨PR Point
한가지의 `bundleName` props를 가지며 필수 prop이고 `string`타입입니다.

- 다크모드일때의 글씨나 아이콘의 색깔을 정하지 않은 느낌이라 어떻게 하는게 좋을까요?
- 사이즈가 줄어들때 768이하일때도 UI가 바뀌어야할까요 아님 모바일일때만 바뀌면될까요?

빠진 부분있으면 말해주세요 피드백 환영입니다! 
### 테스트 코드

```js
<SharedBundleCard bundleName={'데브코스 면접 리스트'} />
```
