### PR TITLE
[#89] SharedBundleDropDown 컴포넌트 구현 v1.0.0

### DIFF
--- a/src/components/BundleDropDown/BundleDropDown.style.ts
+++ b/src/components/BundleDropDown/BundleDropDown.style.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const BundleDropDownWrapper = styled.div<{ $width: string }>`
+  position: absolute;
+  bottom: 0;
+  right: ${({ $width }) => $width};
+`;

--- a/src/components/BundleDropDown/BundleDropDown.tsx
+++ b/src/components/BundleDropDown/BundleDropDown.tsx
@@ -4,6 +4,7 @@ import { useLocation } from 'react-router-dom';
 
 import DropDown from '@/components/common/DropDown';
 import IconWrapper from '@/components/common/IconWrapper';
+import { handleCopyClipBoard } from '@/utils/copyClip';
 
 import { BundleDropDownWrapper } from './BundleDropDown.style';
 import { BundleDropDownProps } from './BundleDropDown.type';
@@ -15,6 +16,8 @@ import { BundleDropDownProps } from './BundleDropDown.type';
           triggerId="dropdown1-btn"
           width="14rem"
         />
+        BundleDropDown는 position: absolute 속성이 있습니다.
+        BundleDropDown 사용하는 부모컴포넌트에 무조건 position: 'relative'를 주어야 합니다. 
  * @description BundleDropDown 컴포넌트
  * @param isDropDownShow 필수) BundleDropDown가 보여지는 유무를 나타내는 상태값입니다.
  * @param setIsDropDownShow 필수) isDropDownShow 상태값을 set하는 함수입니다.
@@ -30,28 +33,20 @@ const BundleDropDown = ({
   width = '12rem',
 }: BundleDropDownProps) => {
   const location = useLocation();
+  const SERVICE_URL = window.location.host;
+  const CURRENT_URL = location.pathname;
 
-  const currentURL = location.pathname;
-
-  const handleCopyClipBoard = async (text: string) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      alert('클립보드에 링크가 복사되었습니다.');
-    } catch (err) {
-      console.log(err);
-    }
-  };
   const OPTIONS = [
     {
       id: 1,
-      title: '리스트 추가',
+      title: '꾸러미 추가',
       rightItem: (
         <IconWrapper $size={'xs'}>
           <MdAddCircleOutline />
         </IconWrapper>
       ),
       handler: () => {
-        console.log('리스트 추가되었습니다'); // 추후 실제 api 연동 과정이 필요
+        console.log('꾸러미가 추가되었습니다'); // 추후 실제 api 연동 과정이 필요
         setIsDropDownShow(!isDropDownShow);
       },
     },
@@ -64,7 +59,7 @@ const BundleDropDown = ({
         </IconWrapper>
       ),
       handler: () => {
-        handleCopyClipBoard(currentURL);
+        handleCopyClipBoard(SERVICE_URL, CURRENT_URL);
         setIsDropDownShow(!isDropDownShow);
       },
     },

--- a/src/components/BundleDropDown/BundleDropDown.tsx
+++ b/src/components/BundleDropDown/BundleDropDown.tsx
@@ -1,5 +1,88 @@
-const BundleDropDown = () => {
-  return <></>;
+import { MdAddCircleOutline } from 'react-icons/md';
+import { RiFileCopyLine } from 'react-icons/ri';
+import { useLocation } from 'react-router-dom';
+
+import DropDown from '@/components/common/DropDown';
+import IconWrapper from '@/components/common/IconWrapper';
+
+import { BundleDropDownWrapper } from './BundleDropDown.style';
+import { BundleDropDownProps } from './BundleDropDown.type';
+
+/**
+ * @summary 사용법    <BundleDropDown
+          isDropDownShow={isDropDownShow}
+          setIsDropDownShow={setIsDropDownShow}
+          triggerId="dropdown1-btn"
+          width="14rem"
+        />
+ * @description BundleDropDown 컴포넌트
+ * @param isDropDownShow 필수) BundleDropDown가 보여지는 유무를 나타내는 상태값입니다.
+ * @param setIsDropDownShow 필수) isDropDownShow 상태값을 set하는 함수입니다.
+ * @param triggerId 필수) 드롭다운 컴포넌트가 isShow=true가 되도록 해주는 HTMLElement의 id입니다.
+ * @param width 선택) width값으로 DropDown의 크기를 설정합니다. string 타입이며 기본값으로 12rem이 들어갑니다.
+ * @returns
+ */
+
+const BundleDropDown = ({
+  isDropDownShow,
+  setIsDropDownShow,
+  triggerId,
+  width = '12rem',
+}: BundleDropDownProps) => {
+  const location = useLocation();
+
+  const currentURL = location.pathname;
+
+  const handleCopyClipBoard = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      alert('클립보드에 링크가 복사되었습니다.');
+    } catch (err) {
+      console.log(err);
+    }
+  };
+  const OPTIONS = [
+    {
+      id: 1,
+      title: '리스트 추가',
+      rightItem: (
+        <IconWrapper $size={'xs'}>
+          <MdAddCircleOutline />
+        </IconWrapper>
+      ),
+      handler: () => {
+        console.log('리스트 추가되었습니다'); // 추후 실제 api 연동 과정이 필요
+        setIsDropDownShow(!isDropDownShow);
+      },
+    },
+    {
+      id: 2,
+      title: '링크 복사',
+      rightItem: (
+        <IconWrapper $size={'xs'}>
+          <RiFileCopyLine />
+        </IconWrapper>
+      ),
+      handler: () => {
+        handleCopyClipBoard(currentURL);
+        setIsDropDownShow(!isDropDownShow);
+      },
+    },
+  ];
+
+  return (
+    <BundleDropDownWrapper $width={width}>
+      <DropDown
+        mode="normal"
+        width={width}
+        height="fit-content"
+        options={OPTIONS}
+        isShow={isDropDownShow}
+        setIsShow={setIsDropDownShow}
+        triggerId={triggerId}
+      />
+    </BundleDropDownWrapper>
+  );
 };
 
 export default BundleDropDown;

--- a/src/components/BundleDropDown/BundleDropDown.tsx
+++ b/src/components/BundleDropDown/BundleDropDown.tsx
@@ -1,0 +1,5 @@
+const BundleDropDown = () => {
+  return <></>;
+};
+
+export default BundleDropDown;

--- a/src/components/BundleDropDown/BundleDropDown.type.ts
+++ b/src/components/BundleDropDown/BundleDropDown.type.ts
@@ -1,0 +1,6 @@
+export interface BundleDropDownProps {
+  isDropDownShow: boolean;
+  setIsDropDownShow: (state: boolean) => void;
+  triggerId: string;
+  width?: string;
+}

--- a/src/components/BundleDropDown/index.ts
+++ b/src/components/BundleDropDown/index.ts
@@ -1,0 +1,1 @@
+export { default } from './BundleDropDown';

--- a/src/components/SharedBundlePage/SharedBundleDropDown/SharedBundleDropDown.style.ts
+++ b/src/components/SharedBundlePage/SharedBundleDropDown/SharedBundleDropDown.style.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const BundleDropDownWrapper = styled.div<{ $width: string }>`
+  position: absolute;
+  bottom: 0;
+  right: ${({ $width }) => $width};
+`;

--- a/src/components/SharedBundlePage/SharedBundleDropDown/SharedBundleDropDown.style.ts
+++ b/src/components/SharedBundlePage/SharedBundleDropDown/SharedBundleDropDown.style.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const BundleDropDownWrapper = styled.div<{ $width: string }>`
+export const SharedBundleDropDownWrapper = styled.div<{ $width: string }>`
   position: absolute;
   bottom: 0;
   right: ${({ $width }) => $width};

--- a/src/components/SharedBundlePage/SharedBundleDropDown/SharedBundleDropDown.tsx
+++ b/src/components/SharedBundlePage/SharedBundleDropDown/SharedBundleDropDown.tsx
@@ -6,32 +6,32 @@ import DropDown from '@/components/common/DropDown';
 import IconWrapper from '@/components/common/IconWrapper';
 import { handleCopyClipBoard } from '@/utils/copyClip';
 
-import { BundleDropDownWrapper } from './SharedBundleDropDown.style';
-import { BundleDropDownProps } from './SharedBundleDropDown.type';
+import { SharedBundleDropDownWrapper } from './SharedBundleDropDown.style';
+import { SharedBundleDropDownProps } from './SharedBundleDropDown.type';
 
 /**
- * @summary 사용법    <BundleDropDown
+ * @summary 사용법    <SharedBundleDropDown
           isDropDownShow={isDropDownShow}
           setIsDropDownShow={setIsDropDownShow}
           triggerId="dropdown1-btn"
           width="14rem"
         />
-        BundleDropDown는 position: absolute 속성이 있습니다.
-        BundleDropDown 사용하는 부모컴포넌트에 무조건 position: 'relative'를 주어야 합니다. 
- * @description BundleDropDown 컴포넌트
- * @param isDropDownShow 필수) BundleDropDown가 보여지는 유무를 나타내는 상태값입니다.
+        SharedBundleDropDown는 position: absolute 속성이 있습니다.
+        SharedBundleDropDown 사용하는 부모컴포넌트에 무조건 position: 'relative'를 주어야 합니다. 
+ * @description SharedBundleDropDown 컴포넌트
+ * @param isDropDownShow 필수) SharedBundleDropDown가 보여지는 유무를 나타내는 상태값입니다.
  * @param setIsDropDownShow 필수) isDropDownShow 상태값을 set하는 함수입니다.
  * @param triggerId 필수) 드롭다운 컴포넌트가 isShow=true가 되도록 해주는 HTMLElement의 id입니다.
  * @param width 선택) width값으로 DropDown의 크기를 설정합니다. string 타입이며 기본값으로 12rem이 들어갑니다.
  * @returns
  */
 
-const BundleDropDown = ({
+const SharedBundleDropDown = ({
   isDropDownShow,
   setIsDropDownShow,
   triggerId,
   width = '12rem',
-}: BundleDropDownProps) => {
+}: SharedBundleDropDownProps) => {
   const location = useLocation();
   const SERVICE_URL = window.location.host;
   const CURRENT_URL = location.pathname;
@@ -66,7 +66,7 @@ const BundleDropDown = ({
   ];
 
   return (
-    <BundleDropDownWrapper $width={width}>
+    <SharedBundleDropDownWrapper $width={width}>
       <DropDown
         mode="normal"
         width={width}
@@ -76,8 +76,8 @@ const BundleDropDown = ({
         setIsShow={setIsDropDownShow}
         triggerId={triggerId}
       />
-    </BundleDropDownWrapper>
+    </SharedBundleDropDownWrapper>
   );
 };
 
-export default BundleDropDown;
+export default SharedBundleDropDown;

--- a/src/components/SharedBundlePage/SharedBundleDropDown/SharedBundleDropDown.tsx
+++ b/src/components/SharedBundlePage/SharedBundleDropDown/SharedBundleDropDown.tsx
@@ -1,0 +1,83 @@
+import { MdAddCircleOutline } from 'react-icons/md';
+import { RiFileCopyLine } from 'react-icons/ri';
+import { useLocation } from 'react-router-dom';
+
+import DropDown from '@/components/common/DropDown';
+import IconWrapper from '@/components/common/IconWrapper';
+import { handleCopyClipBoard } from '@/utils/copyClip';
+
+import { BundleDropDownWrapper } from './SharedBundleDropDown.style';
+import { BundleDropDownProps } from './SharedBundleDropDown.type';
+
+/**
+ * @summary 사용법    <BundleDropDown
+          isDropDownShow={isDropDownShow}
+          setIsDropDownShow={setIsDropDownShow}
+          triggerId="dropdown1-btn"
+          width="14rem"
+        />
+        BundleDropDown는 position: absolute 속성이 있습니다.
+        BundleDropDown 사용하는 부모컴포넌트에 무조건 position: 'relative'를 주어야 합니다. 
+ * @description BundleDropDown 컴포넌트
+ * @param isDropDownShow 필수) BundleDropDown가 보여지는 유무를 나타내는 상태값입니다.
+ * @param setIsDropDownShow 필수) isDropDownShow 상태값을 set하는 함수입니다.
+ * @param triggerId 필수) 드롭다운 컴포넌트가 isShow=true가 되도록 해주는 HTMLElement의 id입니다.
+ * @param width 선택) width값으로 DropDown의 크기를 설정합니다. string 타입이며 기본값으로 12rem이 들어갑니다.
+ * @returns
+ */
+
+const BundleDropDown = ({
+  isDropDownShow,
+  setIsDropDownShow,
+  triggerId,
+  width = '12rem',
+}: BundleDropDownProps) => {
+  const location = useLocation();
+  const SERVICE_URL = window.location.host;
+  const CURRENT_URL = location.pathname;
+
+  const OPTIONS = [
+    {
+      id: 1,
+      title: '꾸러미 추가',
+      rightItem: (
+        <IconWrapper $size={'xs'}>
+          <MdAddCircleOutline />
+        </IconWrapper>
+      ),
+      handler: () => {
+        console.log('꾸러미가 추가되었습니다'); // 추후 실제 api 연동 과정이 필요
+        setIsDropDownShow(!isDropDownShow);
+      },
+    },
+    {
+      id: 2,
+      title: '링크 복사',
+      rightItem: (
+        <IconWrapper $size={'xs'}>
+          <RiFileCopyLine />
+        </IconWrapper>
+      ),
+      handler: () => {
+        handleCopyClipBoard(SERVICE_URL, CURRENT_URL);
+        setIsDropDownShow(!isDropDownShow);
+      },
+    },
+  ];
+
+  return (
+    <BundleDropDownWrapper $width={width}>
+      <DropDown
+        mode="normal"
+        width={width}
+        height="fit-content"
+        options={OPTIONS}
+        isShow={isDropDownShow}
+        setIsShow={setIsDropDownShow}
+        triggerId={triggerId}
+      />
+    </BundleDropDownWrapper>
+  );
+};
+
+export default BundleDropDown;

--- a/src/components/SharedBundlePage/SharedBundleDropDown/SharedBundleDropDown.type.ts
+++ b/src/components/SharedBundlePage/SharedBundleDropDown/SharedBundleDropDown.type.ts
@@ -1,4 +1,4 @@
-export interface BundleDropDownProps {
+export interface SharedBundleDropDownProps {
   isDropDownShow: boolean;
   setIsDropDownShow: (state: boolean) => void;
   triggerId: string;

--- a/src/components/SharedBundlePage/SharedBundleDropDown/SharedBundleDropDown.type.ts
+++ b/src/components/SharedBundlePage/SharedBundleDropDown/SharedBundleDropDown.type.ts
@@ -1,0 +1,6 @@
+export interface BundleDropDownProps {
+  isDropDownShow: boolean;
+  setIsDropDownShow: (state: boolean) => void;
+  triggerId: string;
+  width?: string;
+}

--- a/src/components/SharedBundlePage/SharedBundleDropDown/index.ts
+++ b/src/components/SharedBundlePage/SharedBundleDropDown/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SharedBundleDropDown';

--- a/src/utils/copyClip.ts
+++ b/src/utils/copyClip.ts
@@ -1,0 +1,8 @@
+export const handleCopyClipBoard = async (host: string, pathname: string) => {
+  try {
+    await navigator.clipboard.writeText(`${host}${pathname}`);
+    alert('클립보드에 링크가 복사되었습니다.');
+  } catch (err) {
+    console.log(err);
+  }
+};


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용
공유된 질문꾸러미에 필요한 드롭다운 컴포넌트입니다.
# 📷스크린샷(필요 시)

https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/81172451/2f512979-b191-415c-a648-eb401e1e7404

# ✨PR Point
-  네가지의 props를 받습니다.
- `isDropDownShow` : 필수이며 BundleDropDown가 보여지는 유무를 나타내는 상태값입니다.
- `setIsDropDownShow` 필수이며 isDropDownShow 상태값을 set하는 함수입니다.
- `triggerId`: 필수이며 드롭다운 컴포넌트가 isShow=true가 되도록 해주는 HTMLElement의 id입니다.
- `width`: 선택이며  width값으로 DropDown의 크기를 설정합니다. string 타입이며 기본값으로 12rem이 들어갑니다.  컨텐츠에 오른쪽아래 배치를 하기위해서 style에 `position: absolute` 주고 `top:0`을주고 드롭다운 너비를 제외하고 오른쪽 배치를 하기위해서 `right: width` 값만큼 주었습니다.

- 복사 아이콘 클릭시 현재 URL이 복사됩니다.  참고한 코드[참고](https://w3c.github.io/clipboard-apis/#dom-clipboard-writetext)
- 현주님의 드롭다운 컴포넌트를 사용했는데 잘 사용했는지가 궁금합니다. ! !

### 테스트

```js
import { useState } from 'react';

import BundleDropDown from '@/components/BundleDropDown';
import Button from '@/components/common/Button';

const TestPage = () => {
  const [isDropDownShow, setIsDropDownShow] = useState(false);
  const handleClick = () => {
    setIsDropDownShow(!isDropDownShow);
  };
  return (
    <>
      <Button
        text="클릭"
        id="clickBundle"
        onClick={handleClick}
      />
      <div
        style={{
          width: '500px',
          height: '200px',
          backgroundColor: 'green',
          position: 'relative',
        }}
      >
        <BundleDropDown
          isDropDownShow={isDropDownShow}
          setIsDropDownShow={setIsDropDownShow}
          triggerId="clickBundle"
          width="16rem"
        />
      </div>
    </>
  );
};

export default TestPage;

```