### PR TITLE
[#69] Avatar 컴포넌트 $size props 수정 v1.1.2

### DIFF
--- a/src/components/common/Avatar/Avatar.style.ts
+++ b/src/components/common/Avatar/Avatar.style.ts
@@ -13,8 +13,10 @@ export const AvatarWrapper = styled.div<AvatarProps>`
   position: relative;
   display: inline-block;
   overflow: hidden;
-  width: ${({ $size }) => AvaterSize[$size]};
-  height: ${({ $size }) => AvaterSize[$size]};
+  width: ${({ $size }) =>
+    typeof $size === 'number' ? `${$size}rem` : AvaterSize[$size]};
+  height: ${({ $size }) =>
+    typeof $size === 'number' ? `${$size}rem` : AvaterSize[$size]};
   border: 0.1rem solid ${({ theme }) => theme.gray_100};
   border-radius: 50%;
   background-image: ${({ $src }) =>

--- a/src/components/common/Avatar/Avatar.tsx
+++ b/src/components/common/Avatar/Avatar.tsx
@@ -6,7 +6,7 @@ import { AvatarProps } from './Avatar.type';
  * @description 공통 Avatar 컴포넌트
  * @summary 사용법 1) :  <Avatar $size="mobile" /> (사용자가 설정한 프로필 사진이 없을 때)
  * @summary 사용법 2) : <Avatar $size="pc" $src="/kiwing_square_green.png" /> (사용자가 설정한 프로필 사진이 있을 땐, 이미지 경로를 기입)
- * @param $size : Avatar 컴포넌트 사이즈 (pc, mobile, nav로 기입)
+ * @param $size : Avatar 컴포넌트 사이즈 ("pc" or "mobile" or "nav" or number 타입의 값 으로 기입 (단위는 rem))
  * @param $src : 이미지 경로 (선택 사항)
  * @param...props : 커스텀을 위함
  * @returns

--- a/src/components/common/Avatar/Avatar.type.ts
+++ b/src/components/common/Avatar/Avatar.type.ts
@@ -1,4 +1,4 @@
 export interface AvatarProps extends React.HTMLAttributes<HTMLDivElement> {
-  $size: 'mobile' | 'pc' | 'nav';
+  $size: 'mobile' | 'pc' | 'nav' | number;
   $src?: string;
 }


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용

Avatar 컴포넌트의 $size props를 수정했습니다.
- 기존 `'pc'`, `'mobile'`, `'nav'` 값만 받을 수 있던 상태에서 `number 타입의 커스텀 width 값`을 받을 수 있도록 수정했습니다. (단위는 rem이 적용됩니다.)

# 📷스크린샷(필요 시)

# ✨PR Point

간단한 내용이라 봐주실 코드의 양은 많지 않습니다 !!
