### PR TITLE
[#108] Badge 컴포넌트 v1.2.1

### DIFF
--- a/src/components/common/Badge/Badge.style.ts
+++ b/src/components/common/Badge/Badge.style.ts
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 
-import { FONT_SEMI_BOLD } from '@/constants';
+import { FONT_SEMI_BOLD, MOBILE_MIN } from '@/constants';
 
 import { PropsStyledBadge } from './Badge.type';
 
@@ -56,6 +56,10 @@ export const StyledBadge = styled.span<PropsStyledBadge>`
   ${({ $state }) => {
     return stateStyles[$state];
   }}
+
+  @media screen and (max-width: ${MOBILE_MIN}px) {
+    font-size: ${sizeMapping['xs']};
+  }
 
   @media (hover: hover) and (pointer: fine) {
     &:hover {


### PR DESCRIPTION
뱃지컴포넌트가 280px 이하일때의 최소크기를 지정합니다.

<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용
갤럭시폴드일때 (280px)을 위한 뱃지 폰트크기를 지정해주었습니다.
# 📷스크린샷(필요 시)

# ✨PR Point
`fontSize` 1.1rem으로 주었습니다!