### PR TITLE
[#112] SharedBundleCard 색상 변경 v1.0.1

### DIFF
--- a/src/components/SharedBundleCard/SharedBundleCard.style.ts
+++ b/src/components/SharedBundleCard/SharedBundleCard.style.ts
@@ -6,8 +6,6 @@ export const SharedBundleCardWrapper = styled.div`
   width: 90%;
   max-width: 80rem;
   min-width: 28rem;
-  @media screen and (max-width: ${MOBILE}px) {
-  }
 `;
 
 export const BundleTitle = styled.div`

--- a/src/components/SharedBundleCard/SharedBundleCard.style.ts
+++ b/src/components/SharedBundleCard/SharedBundleCard.style.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { FONT_SEMI_BOLD, MOBILE, MOBILE_MIN } from '@/constants';
+import { FONT_MEDIUM, MOBILE, MOBILE_MIN } from '@/constants';
 
 export const SharedBundleCardWrapper = styled.div`
   width: 90%;
@@ -11,10 +11,10 @@ export const SharedBundleCardWrapper = styled.div`
 export const BundleTitle = styled.div`
   font-size: 2rem;
   padding: 2rem;
-  font-weight: ${FONT_SEMI_BOLD - 50};
+  font-weight: ${FONT_MEDIUM};
   width: 70%;
   text-align: center;
-  color: ${({ theme }) => theme.secondary_color};
+  color: ${({ theme }) => theme.primary_white_text_color};
 
   @media screen and (max-width: ${MOBILE}px) {
     font-size: 1.6rem;

--- a/src/components/SharedBundleCard/SharedBundleCard.style.ts
+++ b/src/components/SharedBundleCard/SharedBundleCard.style.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 
+import { MOBILE_FONT_SIZE, WEB_FONT_SIZE } from '@/constants';
 import { FONT_MEDIUM, MOBILE, MOBILE_MIN } from '@/constants';
 
 export const SharedBundleCardWrapper = styled.div`
@@ -17,12 +18,12 @@ export const BundleTitle = styled.div`
   color: ${({ theme }) => theme.primary_white_text_color};
 
   @media screen and (max-width: ${MOBILE}px) {
-    font-size: 1.6rem;
+    font-size: ${WEB_FONT_SIZE};
     padding: 1.5rem;
   }
 
   @media screen and (max-width: ${MOBILE_MIN}px) {
-    font-size: 1.4rem;
+    font-size: ${MOBILE_FONT_SIZE};
     padding: 1rem;
   }
 `;

--- a/src/components/SharedBundleCard/SharedBundleCard.tsx
+++ b/src/components/SharedBundleCard/SharedBundleCard.tsx
@@ -60,7 +60,7 @@ const SharedBundleCard = ({ bundleName, ...props }: SharedBundleCardProps) => {
                 }}
               />
               <IconWrapper
-                $fillColor={theme.secondary_color}
+                $fillColor={theme.primary_white_text_color}
                 $size={'m'}
                 $hoverIconColor={theme.symbol_secondary_color}
                 onClick={() => {


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용
다크모드일 때의 SharedBundleCard의 색상을 라이트모드와 동일하게 수정하였습니다.
# 📷스크린샷(필요 시)

# ✨PR Point
간단한 색상 변경입니다 !
깜빡하고 전에 1.0.0에 푸쉬를 못하고 머지하여서 ㅠㅠ 다시 수정한 내용 올립니다. ! 