### PR TITLE
[#131] Textarea 컴포넌트 v1.1.0

### DIFF
--- a/src/components/common/Textarea/Textarea.tsx
+++ b/src/components/common/Textarea/Textarea.tsx
@@ -44,7 +44,7 @@ const Textarea = forwardRef(
       errorMessage,
       ...props
     }: TextareaProps,
-    ref?: React.ForwardedRef<HTMLTextAreaElement> | undefined
+    ref?: React.ForwardedRef<HTMLTextAreaElement>
   ) => {
     return (
       <TextareaWrapper

--- a/src/components/common/Textarea/Textarea.tsx
+++ b/src/components/common/Textarea/Textarea.tsx
@@ -1,3 +1,5 @@
+import { forwardRef } from 'react';
+
 import {
   ErrorMessage,
   Label,
@@ -30,37 +32,43 @@ import { TextareaProps } from './Textarea.type';
  * @returns
  */
 
-const Textarea = ({
-  width,
-  height,
-  fontSize,
-  margin,
-  label,
-  placeholder,
-  errorMessage,
-  ...props
-}: TextareaProps) => {
-  return (
-    <TextareaWrapper
-      $width={width}
-      $fontSize={fontSize}
-    >
-      {label && <Label $margin={margin}>{label}</Label>}
-      <StyledTextarea
-        $height={height}
+const Textarea = forwardRef(
+  (
+    {
+      width,
+      height,
+      fontSize,
+      margin,
+      label,
+      placeholder,
+      errorMessage,
+      ...props
+    }: TextareaProps,
+    ref?: React.ForwardedRef<HTMLTextAreaElement> | undefined
+  ) => {
+    return (
+      <TextareaWrapper
+        $width={width}
         $fontSize={fontSize}
-        placeholder={placeholder}
-        {...props}
-      />
-      <ErrorMessage
-        $fontSize={fontSize}
-        $isError={errorMessage?.length === 0}
-        $margin={margin}
       >
-        {errorMessage?.length === 0 ? 'no Error' : errorMessage}
-      </ErrorMessage>
-    </TextareaWrapper>
-  );
-};
+        {label && <Label $margin={margin}>{label}</Label>}
+        <StyledTextarea
+          ref={ref}
+          $height={height}
+          $fontSize={fontSize}
+          placeholder={placeholder}
+          {...props}
+        />
+        <ErrorMessage
+          $fontSize={fontSize}
+          $isError={errorMessage?.length === 0}
+          $margin={margin}
+        >
+          {errorMessage?.length === 0 ? 'no Error' : errorMessage}
+        </ErrorMessage>
+      </TextareaWrapper>
+    );
+  }
+);
 
 export default Textarea;

--- a/src/components/common/Textarea/Textarea.tsx
+++ b/src/components/common/Textarea/Textarea.tsx
@@ -28,7 +28,7 @@ import { TextareaProps } from './Textarea.type';
  * @param label : 선택 | string 타입. textarea 위에 붙는 라벨 역할.
  * @param placeholder : 선택 | string 타입. textarea의 placeholder 역할.
  * @param errorMessage : 선택 | string 타입. textarea의 에러 메시지 역할.
- * @param ...props : 커스텀을 위함 (+ react-hook-form)
+ * @param ...props : textarea 태그 커스텀을 위함
  * @returns
  */
 


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용

Textarea 컴포넌트를 사용하는 곳에서 react-hook-form을 사용할 때 register 함수가 Textarea 컴포넌트 내 textarea 태그를 찾지 못하는 버그가 발생하여 textarea 태그에 ref를 추가했습니다.

# 📷스크린샷(필요 시)

# ✨PR Point

`forwardRef` 를 추가한 후, textarea에 ref를 달아준 것이라 바뀐 코드는 많지 않습니다 !