### PR TITLE
[#132] Input 컴포넌트 v1.1.1

### DIFF
--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -1,3 +1,5 @@
+import { forwardRef } from 'react';
+
 import { ErrorMessage, InputWrapper, Label, StyledInput } from './Input.style';
 import { InputProps } from './Input.type';
 
@@ -24,34 +26,40 @@ import { InputProps } from './Input.type';
  * @returns
  */
 
-const Input = ({
-  width,
-  fontSize,
-  margin,
-  label,
-  placeholder,
-  errorMessage,
-  ...props
-}: InputProps) => {
-  return (
-    <InputWrapper
-      $width={width}
-      $fontSize={fontSize}
-    >
-      {label && <Label $margin={margin}>{label}</Label>}
-      <StyledInput
-        placeholder={placeholder}
-        {...props}
-      />
-      <ErrorMessage
+const Input = forwardRef(
+  (
+    {
+      width,
+      fontSize,
+      margin,
+      label,
+      placeholder,
+      errorMessage,
+      ...props
+    }: InputProps,
+    ref?: React.ForwardedRef<HTMLInputElement> | undefined
+  ) => {
+    return (
+      <InputWrapper
+        $width={width}
         $fontSize={fontSize}
-        $isError={errorMessage?.length === 0}
-        $margin={margin}
       >
-        {errorMessage?.length === 0 ? 'no Error' : errorMessage}
-      </ErrorMessage>
-    </InputWrapper>
-  );
-};
+        {label && <Label $margin={margin}>{label}</Label>}
+        <StyledInput
+          ref={ref}
+          placeholder={placeholder}
+          {...props}
+        />
+        <ErrorMessage
+          $fontSize={fontSize}
+          $isError={errorMessage?.length === 0}
+          $margin={margin}
+        >
+          {errorMessage?.length === 0 ? 'no Error' : errorMessage}
+        </ErrorMessage>
+      </InputWrapper>
+    );
+  }
+);
 
 export default Input;

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -37,7 +37,7 @@ const Input = forwardRef(
       errorMessage,
       ...props
     }: InputProps,
-    ref?: React.ForwardedRef<HTMLInputElement> | undefined
+    ref?: React.ForwardedRef<HTMLInputElement>
   ) => {
     return (
       <InputWrapper

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -22,7 +22,7 @@ import { InputProps } from './Input.type';
  * @param label : 선택 | string 타입. input 위에 붙는 라벨 역할.
  * @param placeholder : 선택 | string 타입. input의 placeholder 역할.
  * @param errorMessage : 선택 | string 타입. input의 에러 메시지 역할.
- * @param ...props : 커스텀을 위함 (+ react-hook-form)
+ * @param ...props : input 태그 커스텀을 위함
  * @returns
  */
 


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용

Input 컴포넌트를 사용하는 곳에서 react-hook-form을 사용할 때 register 함수가 Input 컴포넌트 내 input 태그를 찾지 못하는 버그가 발생하여 input 태그에 ref를 추가했습니다.

# 📷스크린샷(필요 시)

# ✨PR Point
