### PR TITLE
[#149] Badge 컴포넌트 v1.2.2

### DIFF
--- a/src/components/common/Badge/Badge.style.ts
+++ b/src/components/common/Badge/Badge.style.ts
@@ -14,12 +14,12 @@ const sizeMapping = {
 
 const stateStyles = {
   basic: css`
-    background-color: ${({ theme }) => theme.gray_100};
-    color: white;
+    background-color: ${({ theme }) => theme.basic_badge_background_color};
+    color: ${({ theme }) => theme.basic_badge_text_color};
   `,
   focus: css`
     background-color: ${({ theme }) => theme.symbol_color};
-    color: white;
+    color: ${({ theme }) => theme.basic_badge_text_color};
   `,
   hot: css`
     font-weight: ${FONT_SEMI_BOLD};

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -12,6 +12,8 @@ export const lightTheme: object = {
   hotBadge_color: '#f84c4c',
   subscribed_background_color: '#FFE500',
   subscribed_color: '#E3A400',
+  basic_badge_background_color: '#D9D9D9',
+  basic_badge_text_color: '#fefefe',
 
   gray_600: '#565656',
   gray_500: '#5E5E5E',
@@ -42,6 +44,8 @@ export const darkTheme: object = {
   hotBadge_color: '#f84c4c',
   subscribed_background_color: '#FFE500',
   subscribed_color: '#E3A400',
+  basic_badge_background_color: '#565656',
+  basic_badge_text_color: '#e6e6e9',
 
   // 사용성 조사 필요, PR시에 명시해주기 혹은 사전에 논의해주기
   gray_600: '#565656',


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용
다크모드일 때 `basic` 스타일인 뱃지가 잘 보이지않는 이슈로 색상을 변경하였습니다.
# 📷스크린샷(필요 시)
<img width="387" alt="image" src="https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/81172451/2ecc1b4b-a8a4-4a45-84f4-77e50a374606">

# ✨PR Point
전역 테마 스타일에  basic 뱃지 색상을 추가하였습니다.

### 라이트 모드
```js
basic_badge_background_color: '#D9D9D9',
basic_badge_text_color: '#fefefe',
```

### 다크 모드
```js
basic_badge_background_color: '#565656',
basic_badge_text_color: '#e6e6e9',
```

