### PR TITLE
[#151] 프로젝트 세팅 v1.2.0

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,6 +20,18 @@ export default defineConfig({
   },
   plugins: [react()],
   build: {
-    sourcemap: false,
+    sourcemap: 'hidden',
+  },
+  server: {
+    proxy: {
+      // /api 라는 문자열이 target 에 지정한 문자열 https://api-dev.kiwing.kr/ 로 변환되어 사용된다.
+      // 예를 들어 요청 도메인이 http://localhost:5173/api/v1/tags 라면 프록시에 의하여
+      // https://api-dev.kiwing.kr/api/v1/tags 로 요청이 되는 것이다.
+      '/api': {
+        // 프록시가 적용될 요청 경로의 시작 부분. 클라이언트가 보낸 요청의 URL이 api로 시작되면 이 설정이 적용된다.
+        target: 'https://api-dev.kiwing.kr', // 사용할 요청 도메인을 설정한다.
+        changeOrigin: true, // HTTP 요청 헤더의 Host 값을 서버의 호스트와 일치하도록 변경한다. 이를 통해 클라이언트의 요청을 target에 설정된 도메인에서 온 것 처럼 변경할 수 있다.
+      },
+    },
   },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      // /api 라는 문자열이 target 에 지정한 문자열 https://api-dev.kiwing.kr/ 로 변환되어 사용된다.
+      // /api 라는 문자열이 target 에 지정한 문자열 https://api-dev.kiwing.kr/ 로 변환되어 사용된다. << 라고 하는데 설명이 조금 이해가 안가네요;
       // 예를 들어 요청 도메인이 http://localhost:5173/api/v1/tags 라면 프록시에 의하여
       // https://api-dev.kiwing.kr/api/v1/tags 로 요청이 되는 것이다.
       '/api': {


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용
개발환경에서 API 호출을 위한 프록시 서버를 설정하였습니다.


# 📷스크린샷(필요 시)
![image](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/90549862/c73a2c9a-e539-49f2-aae5-f5894c64112a)


# ✨PR Point
테스트 코드
```tsx
import { useEffect, useState } from 'react';

interface tagProps {
  id: number;
  content: string;
}

const TestPage = () => {
  const [tags, setTags] = useState([]);
  useEffect(() => {
    if (tags.length === 0) {
      fetch('/api/v1/tags')
        .then((res) => res.json())
        .then((resp) => setTags(resp.data));
    }
  });
  // 요기다가 하시면 됩니다
  console.log(tags);
  return (
    <>
      <div>테스트 페이지 입니다.</div>
      {tags.length === 0 ? (
        <div>Loading</div>
      ) : (
        <>
          {tags.map((val: tagProps) => {
            return (
              <div key={val.id}>
                <span>
                  {val.id} {val.content}
                </span>
              </div>
            );
          })}
        </>
      )}
    </>
  );
};

export default TestPage;
```

약간 세팅하면서 이해가 안갔던게 `/api 라는 문자열이 target 에 지정한 문자열 https://api-dev.kiwing.kr/ 로 변환되어 사용된다.` 는 문구가 있더라고요.
제가 이해하기로는 fetch('/api/v1/tags')가 fetch('https://api-dev.kiwing.kr/v1/tags') 로 바뀌는 줄 알았는데 
막상 바뀌는 호출은 fetch('https://api-dev.kiwing.kr/api/v1/tags')로 바뀝니다.

어쨌든 위와 같이 사용하면 동작은 잘되고 이 의문점 빼고는... 동작은 합니다..!

++ 제가 제대로 이해를 못했었네요ㅠㅠㅠㅠㅠ 자세한 건 [현주님이 정리해주신 글](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/pull/153#pullrequestreview-1909459272)을 참고해주세요!!