### PR TITLE
[#152] Input 컴포넌트 v1.2.1

### DIFF
--- a/src/components/common/Input/Input.style.ts
+++ b/src/components/common/Input/Input.style.ts
@@ -1,9 +1,29 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { MOBILE } from '@/constants';
 import { Col } from '@/styles/globalStyles';
 
 import { InputStyledProps } from './Input.type';
+
+const borderStyle = {
+  onlyBottom: css`
+    border-bottom: 0.15rem solid ${({ theme }) => theme.primary_color};
+    border-radius: 0;
+
+    &:focus {
+      border-bottom: 0.15rem solid
+        ${({ theme }) => theme.symbol_secondary_color};
+    }
+  `,
+  all: css`
+    border: 0.15rem solid ${({ theme }) => theme.primary_color};
+    border-radius: 10rem;
+
+    &:focus {
+      border: 0.15rem solid ${({ theme }) => theme.symbol_secondary_color};
+    }
+  `,
+};
 
 export const InputWrapper = styled(Col)<InputStyledProps>`
   @media screen and (max-width: ${MOBILE}px) {
@@ -19,19 +39,17 @@ export const Label = styled.label<InputStyledProps>`
   margin-bottom: ${(props) => (props.$margin ? props.$margin : 1.5)}rem;
 `;
 
-export const StyledInput = styled.input`
+export const StyledInput = styled.input<InputStyledProps>`
   color: ${({ theme }) => theme.primary_color};
   background-color: transparent;
-  padding: 0 0.4rem 0.2rem 0.4rem;
+  padding: 0.2rem 0.4rem 0.2rem 0.4rem;
   box-sizing: border-box;
   border: none;
-  border-bottom: 0.15rem solid ${({ theme }) => theme.primary_color};
   outline: none;
   transition: border 0.2s;
 
-  &:focus {
-    border-bottom: 0.15rem solid ${({ theme }) => theme.symbol_secondary_color};
-  }
+  ${({ $isOnlyBorderBottom }) =>
+    $isOnlyBorderBottom ? borderStyle['onlyBottom'] : borderStyle['all']}
 
   &::placeholder {
     color: ${({ theme }) => theme.gray_300};

--- a/src/components/common/Input/Input.style.ts
+++ b/src/components/common/Input/Input.style.ts
@@ -42,7 +42,9 @@ export const Label = styled.label<InputStyledProps>`
 export const StyledInput = styled.input<InputStyledProps>`
   color: ${({ theme }) => theme.primary_color};
   background-color: transparent;
-  padding: 0.2rem 0.4rem 0.2rem 0.4rem;
+  /* padding: 0.2rem 0.4rem 0.2rem 0.4rem; */
+  padding: ${(props) =>
+    props.$isOnlyBorderBottom ? '0.2rem 0.4rem' : '0.5rem 1rem'};
   box-sizing: border-box;
   border: none;
   outline: none;

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -14,6 +14,7 @@ import { InputProps } from './Input.type';
         label={'라벨이다'}
         placeholder={'닉네임 써라'}
         errorMessage={'에러다'}
+        isOnlyBorderBottom={true}
       />
  * @param width : 필수 | string 타입. input의 너비를 의미함. (px or rem or % 로 기입)
  * @param fontSize : 선택 | number 타입. 라벨, input, 에러 메시지의 폰트 사이즈를 의미. 생략 시 기본 값으로 1.6이 설정. 
@@ -22,6 +23,7 @@ import { InputProps } from './Input.type';
  * @param label : 선택 | string 타입. input 위에 붙는 라벨 역할.
  * @param placeholder : 선택 | string 타입. input의 placeholder 역할.
  * @param errorMessage : 선택 | string 타입. input의 에러 메시지 역할.
+ * @param isOnlyBorderBottom : 선택 | boolean 타입. input의 border를 아래만 줄것인지 사방면으로 줄 것인지 결정하는 역할
  * @param ...props : input 태그 커스텀을 위함
  * @returns
  */

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -35,6 +35,8 @@ const Input = forwardRef(
       label,
       placeholder,
       errorMessage,
+      inputType = 'text',
+      isOnlyBorderBottom = true,
       ...props
     }: InputProps,
     ref?: React.ForwardedRef<HTMLInputElement>
@@ -46,8 +48,10 @@ const Input = forwardRef(
       >
         {label && <Label $margin={margin}>{label}</Label>}
         <StyledInput
+          type={inputType}
           ref={ref}
           placeholder={placeholder}
+          $isOnlyBorderBottom={isOnlyBorderBottom}
           {...props}
         />
         <ErrorMessage

--- a/src/components/common/Input/Input.type.ts
+++ b/src/components/common/Input/Input.type.ts
@@ -5,6 +5,8 @@ export interface InputProps extends React.HTMLAttributes<HTMLInputElement> {
   label?: string;
   placeholder?: string;
   errorMessage?: string;
+  inputType?: string;
+  isOnlyBorderBottom?: boolean;
 }
 
 export interface InputStyledProps {
@@ -12,4 +14,5 @@ export interface InputStyledProps {
   $fontSize?: number;
   $margin?: number;
   $isError?: boolean;
+  $isOnlyBorderBottom?: boolean;
 }

--- a/src/styles/globalStyles.ts
+++ b/src/styles/globalStyles.ts
@@ -22,7 +22,7 @@ export const GlobalStyle = createGlobalStyle`
       font-size: 62.5%;
       box-sizing: border-box;
       
-      input:not([type=color]):not([type=checkbox]), button, textarea, select {
+      input:not([type=color]):not([type=checkbox]):not([type=text]), button, textarea, select {
         border-radius: 0;
       }
 


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용

Input 컴포넌트에 border 옵션을 줄 수 있도록 수정했습니다.

- `isOnlyBorderBottom` props를 사용하며, 
true일 때는 Input 컴포넌트의 border가 아래만 나타나고, false일 때는 사방면 border가 적용 됩니다.

# 📷스크린샷(필요 시)

# 사용 방법

```typescript

import Input from '@/components/common/Input';

const TestPage = () => {
  return (
    <>
      <Input
        width={'200px'}
        isOnlyBorderBottom={false}
      />
      {/* 사방면 border */}
      <Input
        width={'200px'}
        isOnlyBorderBottom={true}
      />
      {/* 아래만 border */}
    </>
  );
};

export default TestPage;


```

# ✨PR Point

- globalStyle.ts 파일을 수정했습니다.
  - 저번 이슈 사항이었던 `IOS 환경에서 border-bottom이 둥글게 나오는 문제` 를 해결하기 위해 추가했던 코드를 수정했는데, 모바일 환경에서 문제 없는지 한 번씩만 테스트 부탁 드립니다 !! 제가 했을 땐 문제가 없었는데 다른 팀원분들 환경에서는 어떻게 될지 모르겠어서 부탁 드립니다 ㅠㅠ


해당 PR이 머지 되는대로 SearchBar 컴포넌트에 적용하여 SearchBar v2.0.0 PR 올릴 예정입니다 !