### PR TITLE
[#170] 공통 - Input 컴포넌트 v1.3.1

### DIFF
--- a/src/components/common/Input/Input.style.ts
+++ b/src/components/common/Input/Input.style.ts
@@ -58,6 +58,7 @@ export const StyledInput = styled.input<InputStyledProps>`
 
   &:disabled {
     color: ${({ theme }) => theme.gray_400};
+    cursor: not-allowed;
   }
 `;
 

--- a/src/components/common/Input/Input.style.ts
+++ b/src/components/common/Input/Input.style.ts
@@ -56,6 +56,10 @@ export const StyledInput = styled.input<InputStyledProps>`
   &::placeholder {
     color: ${({ theme }) => theme.gray_300};
   }
+
+  &:disabled {
+    color: ${({ theme }) => theme.gray_400};
+  }
 `;
 
 export const ErrorMessage = styled.div<InputStyledProps>`

--- a/src/components/common/Input/Input.style.ts
+++ b/src/components/common/Input/Input.style.ts
@@ -42,7 +42,6 @@ export const Label = styled.label<InputStyledProps>`
 export const StyledInput = styled.input<InputStyledProps>`
   color: ${({ theme }) => theme.primary_color};
   background-color: transparent;
-  /* padding: 0.2rem 0.4rem 0.2rem 0.4rem; */
   padding: ${(props) =>
     props.$isOnlyBorderBottom ? '0.2rem 0.4rem' : '0.5rem 1rem'};
   box-sizing: border-box;

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -39,6 +39,7 @@ const Input = forwardRef(
       errorMessage,
       inputType = 'text',
       isOnlyBorderBottom = true,
+      isDisabled,
       ...props
     }: InputProps,
     ref?: React.ForwardedRef<HTMLInputElement>
@@ -54,6 +55,7 @@ const Input = forwardRef(
           ref={ref}
           placeholder={placeholder}
           $isOnlyBorderBottom={isOnlyBorderBottom}
+          disabled={isDisabled}
           {...props}
         />
         <ErrorMessage

--- a/src/components/common/Input/Input.type.ts
+++ b/src/components/common/Input/Input.type.ts
@@ -7,6 +7,7 @@ export interface InputProps extends React.HTMLAttributes<HTMLInputElement> {
   errorMessage?: string;
   inputType?: string;
   isOnlyBorderBottom?: boolean;
+  isDisabled?: boolean;
 }
 
 export interface InputStyledProps {


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용

Input 컴포넌트에 `isDisabled` props를 추가했습니다.
- `isDiabled` props는 input의 disabled 설정을 제어할 수 있는 props입니다.
- input이 disabled 되면 사용자에게 시각적으로 알려주기 위해 글자 색을 gray_400으로 설정했습니다.

브랜치 명이 잘못된 것을 이제 봤네요....ㅠㅠ 주의하겠습니다...!!

# 📷스크린샷(필요 시)

![스크린샷 2024-03-03 오후 7 49 27](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/942fd112-081b-4648-b583-120684bce8de)

- 위에가 disabled 된 input이고 밑에는 disabled가 적용 안됐고 placeholder가 출력된 것입니다 !

<details>
<summary>Test</summary>
<div markdown="1">       

```typescript
import { useForm } from 'react-hook-form';

import Input from '@/components/common/Input';

interface InputTypes {
  title: string;
  content: string;
}

const TestPage = () => {
  const { register } = useForm<InputTypes>({
    defaultValues: {
      title: '제목의 기본값을 뭐로 할까',
      content: '그러게',
    },
  });

  return (
    <>
      <Input
        width={'500px'}
        placeholder="이메일을 입력하세요"
        isDisabled={true}
        {...register('title')}
      />
      <Input
        width={'500px'}
        placeholder="이메일을 입력하세요."
      />
    </>
  );
};

export default TestPage;

``` 


</div>
</details>


# ✨PR Point

- `isDisabled = true`로 설정한다면 **기본값은 어떻게 설정해야 하는가 !!!**
  - => 이는 react-hook-form의 useForm()로 함수들을 가져올 때 `defaultValues`로 기본값을 설정해줄 수 있습니다 !
```typescript

interface InputTypes {
  title: string;
  content: string;
}

const {
    register,
    ...
  } = useForm<InputTypes>({
    defaultValues: {
      title: '제목의 기본값을 뭐로 할까',
      content: '그러게',
    },
  });

```

위 코드를 예시로 하면, `title, content`는 register에 등록 될 이름이라고 생각하시면 되고, useForm() 안에 defaultValues 옵션으로 `{register에 등록할 이름} : {해당 register에 기본값으로 쓸 내용}` 을 기입하시면 됩니다 !!
(아마 제 설명 보다는 공식문서 혹은 다른 블로그의 내용이 더 쉽고 자세할 것이기에 제 코드는 참고용으로 봐주시면 될 것 같아요 !!)


- disabled 되면 geay_400으로 색상을 설정했는데 placeholder와 헷갈릴까요 ? (위 사진에서 비교해보실 수 있습니다 !)
  - placeholder 색상은 gray_300입니다 !
