### PR TITLE
[#167] 전역 레이아웃 수정 v1.1.0

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -5,9 +5,12 @@ import { MOBILE } from '@/constants';
 const Layout = styled.div`
   width: 100%;
   height: 100%;
-  padding-top: 1rem;
+  padding-top: 7.525rem;
+  box-sizing: border-box;
 
   @media screen and (max-width: ${MOBILE}px) {
+    width: 100%;
+    height: 100%;
     padding-top: 5rem;
     padding-bottom: 6rem;
   }

--- a/src/components/common/EasterEgg/EasterEgg.style.ts
+++ b/src/components/common/EasterEgg/EasterEgg.style.ts
@@ -10,7 +10,9 @@ export const EasterEggContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  position: absolute;
+  position: fixed;
+  top: 0;
+
   width: 100%;
   height: 100%;
   overflow: hidden;

--- a/src/components/common/Navigator/WebNavBar/WebNavBar.style.tsx
+++ b/src/components/common/Navigator/WebNavBar/WebNavBar.style.tsx
@@ -1,20 +1,27 @@
 import styled from 'styled-components';
 
-import { FONT_MEDIUM, MOBILE } from '@/constants';
+import { FONT_MEDIUM, MOBILE, NAVIGATER } from '@/constants';
 import { Row } from '@/styles/globalStyles';
 
 import { WebNavBarItemProps } from './WebNavBar.type';
 
 export const WebNavBarWrapper = styled.nav`
   display: flex;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+
   align-items: center;
   justify-content: space-between;
   margin: 0 auto;
   padding: 3rem 2rem 0.5rem 2rem;
+  z-index: ${NAVIGATER};
 
   max-width: 1140px;
   font-size: 2rem;
   font-weight: ${FONT_MEDIUM};
+  background-color: ${({ theme }) => theme.background_color};
   color: ${(props) => props.theme.primary_color};
   user-select: none;
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -8,7 +8,7 @@ export const MOBILE_MIN = 280; // 280px
 // ------------------------------------------ SCREEN //
 
 // Zindex //
-export const NAVIGATER = 2;
+export const NAVIGATER = 9;
 export const DROP_DOWN = 3;
 export const MODAL_BACKGROUND = 4;
 export const MODAL_LAYOUT = 5;

--- a/src/pages/NotFoundPage/NotFound.style.ts
+++ b/src/pages/NotFoundPage/NotFound.style.ts
@@ -32,7 +32,7 @@ const slideOut = keyframes`
 export const NotFoundLayout = styled(Col)`
   margin: 0 auto;
   width: auto;
-  height: 100vh;
+  height: 100%;
   justify-content: center;
   align-items: center;
   gap: 2rem;

--- a/src/styles/globalStyles.ts
+++ b/src/styles/globalStyles.ts
@@ -34,6 +34,10 @@ export const GlobalStyle = createGlobalStyle`
       -webkit-tap-highlight-color: transparent;
     }
 
+    #root {
+      height: 100%;
+    }
+
     button {
     cursor: pointer;
     background-color: Transparent;


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용
전역 레이아웃 속성을 변경하였습니다.
또한 연관된 일부 간단한 속성을 변경하였습니다.

기존에는 웹에서 따로 속성을 부여하지 않고 자동적으로 스크롤 하게 했었다면
변경 값에서는 상단 내비게이션 바 만큼 padding값을 주어 떨어트려두었습니다.

또한 상단 내비게이션 바는 스크롤이 동작해도 항상 제자리에 유지됩니다.

# 📷스크린샷(필요 시)
[kiwing_layout_1.1.0.webm](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/90549862/08b74513-d640-4675-8dba-585171169659)

# ✨PR Point
- 자잘자잘한 일부 변경사항이 있는데 변경된 레이아웃에 맞춘 코드입니다.
- 내비게이터의 z-index값이 많이 올랐습니다. 2 -> 9
- 페이지에서 사용하실때, 일반적인 전체 스크롤의 경우 그냥 height 100%로 래핑해주시면 됩니다!