### PR TITLE
[#185] 공통 - SearchBar v2.1.0

### DIFF
--- a/src/components/common/SearchBar/SearchBar.tsx
+++ b/src/components/common/SearchBar/SearchBar.tsx
@@ -46,6 +46,7 @@ const SearchBar = ({
     formState: { errors },
   } = useFormContext();
 
+  // TODO: warning 원인 찾아서 해결하기. (useCallback에 의존성을 주면 함수 실행 자체가 안됨... 현재의 형태 말고는 debounce가 정상적으로 동작하는 형태가 없었는데, 코드 품질을 위해 해결해야함.)
   const SearchSubmit = useCallback(
     debounce(() => {
       if (!errors[REGISTER]?.message) {

--- a/src/components/common/SearchBar/SearchBar.tsx
+++ b/src/components/common/SearchBar/SearchBar.tsx
@@ -1,3 +1,5 @@
+import { debounce } from 'lodash';
+import { useCallback } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { MdSearch } from 'react-icons/md';
 
@@ -44,13 +46,14 @@ const SearchBar = ({
     formState: { errors },
   } = useFormContext();
 
-  const SearchSubmit = () => {
-    if (handleSearchSubmit) {
+  const SearchSubmit = useCallback(
+    debounce(() => {
       if (!errors[REGISTER]?.message) {
         handleSearchSubmit();
       }
-    }
-  };
+    }, 500),
+    []
+  );
 
   const { isMobileSize } = useResize();
 

--- a/src/components/common/SearchBar/SearchBar.tsx
+++ b/src/components/common/SearchBar/SearchBar.tsx
@@ -47,6 +47,7 @@ const SearchBar = ({
   } = useFormContext();
 
   // TODO: warning 원인 찾아서 해결하기. (useCallback에 의존성을 주면 함수 실행 자체가 안됨... 현재의 형태 말고는 debounce가 정상적으로 동작하는 형태가 없었는데, 코드 품질을 위해 해결해야함.)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const SearchSubmit = useCallback(
     debounce(() => {
       if (!errors[REGISTER]?.message) {


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용

SearchBar 컴포넌트 사용 시, submit 할 때 실행되는 함수에 `디바운스`를 적용했습니다.
- 검색 바에 검색어 입력 후 엔터를 꾹 누르면 submit 이벤트가 여러 번 발생하여 함수가 여러 번 실행되는 문제가 있었습니다.
이는 서버의 과부화를 일으킬 수 있기에 디바운스를 걸어주어 문제를 해결할 수 있었습니다.

# 📷스크린샷(필요 시)

<details>
<summary>Test</summary>
<div markdown="1">       

```typescript
import { FormProvider, useForm } from 'react-hook-form';

import SearchBar from '@/components/common/SearchBar';

const TestPage = () => {
  const methods = useForm({ mode: 'onBlur' });

  const REGISTER = 'bundleSearch';
  const bundleValidate = {
    minLength: {
      value: 2,
      message: '최소 2글자 이상 입력해주세요',
    },
  };

  const onSubmit = () => {
    // 검색 시 실행할 함수를 입력합니다.
    console.log(methods.getValues(REGISTER));
  };

  return (
    <>
      <FormProvider {...methods}>
        <SearchBar
          // fontSize={2}
          handleSearchSubmit={onSubmit}
          maxWidth={'500px'}
          REGISTER={REGISTER}
          VALIDATE={bundleValidate}
        />
      </FormProvider>
    </>
  );
};

export default TestPage;


``` 


</div>
</details>

# ✨PR Point

- lodash를 이용하여 디바운스를 추가해봤습니다 !! 봐주실 코드는 많이 없어요 !

- SearchBar.tsx > SearchSubmit 함수 쪽에서 `React Hook useCallback received a function whose dependencies are unknown. Pass an inline function instead.`
라는 warning이 뜨고 있는데, useCallback에 의존성 배열도 추가해보고, useCallback 안에서 debounce 함수를 화살표 함수로 바꿔 적용도 해봤는데, 지금 코드 형태 이외에는 디바운스가 정상적으로 동작하는 경우가 없었습니다... 혹시 해당 warning에 대해 해결책을 알고 있는 선생님들 계실까요...?
=> 일단 임시 방편으로 warning 안뜨게 주석 추가 해놓은 상태입니다 !

```typescript
// 현재 코드 상태
  const SearchSubmit = useCallback(
    debounce(() => {
      if (!errors[REGISTER]?.message) {
        handleSearchSubmit();
      }
    }, 500),
    []
  );

// 시도해본 코드들
  const SearchSubmit = useCallback(
    () =>
      debounce(() => {
        if (!errors[REGISTER]?.message) {
          handleSearchSubmit();
        }
      }, 500),
    []
  );

// 해당 경우가 warning은 없어지는데 submit 이벤트 발생 시 SearchSubmit 함수 실행 자체가 안됩니다..
  const SearchSubmit = useCallback(
    () =>
      debounce(() => {
        if (!errors[REGISTER]?.message) {
          handleSearchSubmit();
        }
      }, 500),
    [REGISTER, errors, handleSearchSubmit]
  );

```
