### PR TITLE
[#200] MyBundleMenu v1.0.0

### DIFF
--- a/src/components/MyBundle/MyBundleMenu/MyBundleMenu.style.ts
+++ b/src/components/MyBundle/MyBundleMenu/MyBundleMenu.style.ts
@@ -1,0 +1,39 @@
+import styled from 'styled-components';
+
+export const Options = styled.div`
+  height: 100%;
+
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  cursor: auto;
+`;
+
+export const Item = styled.div`
+  height: fit-content;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem 1rem 2rem;
+  cursor: pointer;
+  box-sizing: border-box;
+
+  transition: all 0.2s ease;
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      background-color: ${({ theme }) => theme.border_color};
+    }
+  }
+
+  &:active {
+    background-color: ${({ theme }) => theme.border_color};
+  }
+
+  &:last-child {
+    border-radius: 0 0 0.6rem 0.6rem;
+  }
+  &:first-child {
+    border-radius: 0.6rem 0.6rem 0 0;
+  }
+`;

--- a/src/components/MyBundle/MyBundleMenu/MyBundleMenu.style.ts
+++ b/src/components/MyBundle/MyBundleMenu/MyBundleMenu.style.ts
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
 
-export const Options = styled.div`
-  height: 100%;
+import { Col } from '@/styles/globalStyles';
 
-  overflow: auto;
-  display: flex;
-  flex-direction: column;
+export const Options = styled(Col)`
+  height: 100%;
+  overflow: hidden;
   cursor: auto;
+  flex-shrink: 0;
 `;
 
 export const Item = styled.div`
@@ -17,6 +17,7 @@ export const Item = styled.div`
   padding: 1rem 2rem 1rem 2rem;
   cursor: pointer;
   box-sizing: border-box;
+  flex-shrink: 0;
 
   transition: all 0.2s ease;
 
@@ -36,4 +37,8 @@ export const Item = styled.div`
   &:first-child {
     border-radius: 0.6rem 0.6rem 0 0;
   }
+`;
+
+export const Text = styled.div`
+  flex-shrink: 0;
 `;

--- a/src/components/MyBundle/MyBundleMenu/MyBundleMenu.tsx
+++ b/src/components/MyBundle/MyBundleMenu/MyBundleMenu.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react';
+import { FiEdit3 } from 'react-icons/fi';
+import { RiDeleteBin5Line, RiFileCopyLine } from 'react-icons/ri';
+
+import BorderBox from '@/components/common/BorderBox';
+import IconWrapper from '@/components/common/IconWrapper';
+import Toggle from '@/components/common/Toggle';
+import { PATH } from '@/constants/router';
+import { Bundle } from '@/types';
+import { handleCopyClipBoard } from '@/utils/copyClip';
+
+import { Item, Options } from './MyBundleMenu.style';
+
+const MyBundleMenu = ({ bundle }: { bundle: Bundle | null }) => {
+  const [isShared, setIsShared] = useState(false);
+
+  const handleItemClick = (handler: (() => void) | undefined) => {
+    if (handler) {
+      handler();
+    }
+  };
+
+  const handleDeleteBundle = () => {
+    if (!bundle) return;
+    confirm(`id ${bundle.id} 꾸러미를 삭제하시겠습니까?`);
+    // @TODO 추후에 꾸러미 삭제 API 함수를 호출합니다.
+  };
+
+  const handleEditBundle = () => {
+    if (!bundle) return;
+    console.log(`id ${bundle.id} 꾸러미 편집`);
+    // @TODO 추후에 꾸러미 편집을 할 수 있는 모달을 띄웁니다.
+  };
+
+  const options = [
+    {
+      id: 1,
+      title: '공개 여부',
+      rightItem: (
+        <Toggle
+          on={isShared}
+          width="4rem"
+        />
+      ),
+
+      handler: () => {
+        if (!bundle) return;
+        setIsShared(!isShared);
+        // @TODO 추후에 꾸러미 공개/비공개를 결정하는 api 로직을 연동합니다.
+      },
+    },
+
+    {
+      id: 2,
+      title: '링크 복사',
+      rightItem: (
+        <IconWrapper $size={'xs'}>
+          <RiFileCopyLine />
+        </IconWrapper>
+      ),
+      handler: () => {
+        if (!bundle) return;
+        if (isShared) {
+          const host = window.location.host;
+          const pathname = `${PATH.SHARED}/${bundle?.id}`;
+          handleCopyClipBoard(host, pathname);
+        } else {
+          // @TODO 추후에 alert -> 토스트 알림으로 변경합니다.
+          alert('공개된 리스트만 링크를 복사할 수 있습니다.');
+        }
+      },
+    },
+    {
+      id: 3,
+      title: '꾸러미 삭제',
+      rightItem: (
+        <IconWrapper $size={'xs'}>
+          <RiDeleteBin5Line />
+        </IconWrapper>
+      ),
+      handler: () => {
+        if (!bundle) return;
+        handleDeleteBundle();
+      },
+    },
+    {
+      id: 4,
+      title: '꾸러미 편집',
+      rightItem: (
+        <IconWrapper $size={'xs'}>
+          <FiEdit3 />
+        </IconWrapper>
+      ),
+      handler: () => {
+        if (!bundle) return;
+        handleEditBundle();
+      },
+    },
+  ];
+  return (
+    <BorderBox
+      width="100%"
+      height="fit-content"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+      }}
+    >
+      <Options>
+        {options.map((option) => (
+          <Item
+            key={option.id}
+            onClick={() => handleItemClick(option.handler)}
+          >
+            {option.title}
+            {option.rightItem}
+          </Item>
+        ))}
+      </Options>
+    </BorderBox>
+  );
+};
+
+export default MyBundleMenu;

--- a/src/components/MyBundle/MyBundleMenu/MyBundleMenu.tsx
+++ b/src/components/MyBundle/MyBundleMenu/MyBundleMenu.tsx
@@ -6,12 +6,12 @@ import BorderBox from '@/components/common/BorderBox';
 import IconWrapper from '@/components/common/IconWrapper';
 import Toggle from '@/components/common/Toggle';
 import { PATH } from '@/constants/router';
-import { Bundle } from '@/types';
 import { handleCopyClipBoard } from '@/utils/copyClip';
 
 import { Item, Options } from './MyBundleMenu.style';
+import { MyBundleMenuProps } from './MyBundleMenu.type';
 
-const MyBundleMenu = ({ bundle }: { bundle: Bundle | null }) => {
+const MyBundleMenu = ({ bundle }: MyBundleMenuProps) => {
   const [isShared, setIsShared] = useState(false);
 
   const handleItemClick = (handler: (() => void) | undefined) => {
@@ -21,13 +21,11 @@ const MyBundleMenu = ({ bundle }: { bundle: Bundle | null }) => {
   };
 
   const handleDeleteBundle = () => {
-    if (!bundle) return;
     confirm(`id ${bundle.id} 꾸러미를 삭제하시겠습니까?`);
     // @TODO 추후에 꾸러미 삭제 API 함수를 호출합니다.
   };
 
   const handleEditBundle = () => {
-    if (!bundle) return;
     console.log(`id ${bundle.id} 꾸러미 편집`);
     // @TODO 추후에 꾸러미 편집을 할 수 있는 모달을 띄웁니다.
   };
@@ -44,7 +42,6 @@ const MyBundleMenu = ({ bundle }: { bundle: Bundle | null }) => {
       ),
 
       handler: () => {
-        if (!bundle) return;
         setIsShared(!isShared);
         // @TODO 추후에 꾸러미 공개/비공개를 결정하는 api 로직을 연동합니다.
       },
@@ -59,7 +56,6 @@ const MyBundleMenu = ({ bundle }: { bundle: Bundle | null }) => {
         </IconWrapper>
       ),
       handler: () => {
-        if (!bundle) return;
         if (isShared) {
           const host = window.location.host;
           const pathname = `${PATH.SHARED}/${bundle?.id}`;
@@ -79,7 +75,6 @@ const MyBundleMenu = ({ bundle }: { bundle: Bundle | null }) => {
         </IconWrapper>
       ),
       handler: () => {
-        if (!bundle) return;
         handleDeleteBundle();
       },
     },

--- a/src/components/MyBundle/MyBundleMenu/MyBundleMenu.tsx
+++ b/src/components/MyBundle/MyBundleMenu/MyBundleMenu.tsx
@@ -8,7 +8,7 @@ import Toggle from '@/components/common/Toggle';
 import { PATH } from '@/constants/router';
 import { handleCopyClipBoard } from '@/utils/copyClip';
 
-import { Item, Options } from './MyBundleMenu.style';
+import { Item, Options, Text } from './MyBundleMenu.style';
 import { MyBundleMenuProps } from './MyBundleMenu.type';
 
 const MyBundleMenu = ({ bundle }: MyBundleMenuProps) => {
@@ -108,8 +108,8 @@ const MyBundleMenu = ({ bundle }: MyBundleMenuProps) => {
             key={option.id}
             onClick={() => handleItemClick(option.handler)}
           >
-            {option.title}
-            {option.rightItem}
+            <Text>{option.title}</Text>
+            <Text>{option.rightItem}</Text>
           </Item>
         ))}
       </Options>

--- a/src/components/MyBundle/MyBundleMenu/MyBundleMenu.type.ts
+++ b/src/components/MyBundle/MyBundleMenu/MyBundleMenu.type.ts
@@ -1,0 +1,5 @@
+import { Bundle } from '@/types';
+
+export interface MyBundleMenuProps {
+  bundle: Bundle;
+}

--- a/src/components/MyBundle/MyBundleMenu/index.ts
+++ b/src/components/MyBundle/MyBundleMenu/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MyBundleMenu';


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용
내 질문 관리 페이지 오른쪽 상단에 위치한 MyBundleMenu를 구현했습니다.
UI 위주로 작업했습니다.
MyBundleDropdown과 로직이 거의 일치하여 추후에 api 연동 작업 후 공통된 부분을 따로 빼는 작업을 진행할 예정입니다.

# 📷스크린샷(필요 시)
![image](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/78135416/f9d047a4-a99a-40b4-bfa3-1ac899067195)

# ✨PR Point
- UI 위주에 MyBundleDropDown과 유사하여 큰 내용은 없습니다!