### PR TITLE
[#194] 프로젝트 세팅(전역 스타일에 조건문 추가) v1.2.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     />
     <meta
       property="og:url"
-      content="https://kiwing.kr"
+      content="https://kiwing.kr/"
     />
     <meta
       property="og:image"

--- a/src/styles/globalStyles.ts
+++ b/src/styles/globalStyles.ts
@@ -1,10 +1,13 @@
 import styled, { createGlobalStyle } from 'styled-components';
 import { normalize } from 'styled-normalize';
 
+import { MOBILE } from '@/constants';
+
 export const GlobalStyle = createGlobalStyle`
     ${normalize}
 
-    * {
+    @media not all and (max-width: ${MOBILE}px) {
+      * {
         &::-webkit-scrollbar {
           width: 0.4rem;
         }
@@ -12,7 +15,8 @@ export const GlobalStyle = createGlobalStyle`
           background-color: ${(props) => props.theme.border_color};
           border-radius: 100px;
         }
-    }   
+      }
+    }
 
     html,   
     body {


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용
모바일 환경에서 스크롤바가 영역을 차지하는 이슈를 해결하였습니다.

### 원인
모바일 환경에서 스크롤 바의 기본값은 overlay형태로 기본 영역을 차지하지 않습니다.
대표적인 삼성 갤럭시와 아이폰 사파리도 동일한 방식으로 구현됩니다.

하지만 전역에 있던 아래 코드가 임의로 스크롤바의 영역을 생성했고
그래서 모바일 환경에서의 문제점이 발생하였습니다.
```tsx
  * {
      &::-webkit-scrollbar {
        width: 0.4rem;
      }
      &::-webkit-scrollbar-thumb {
        background-color: ${(props) => props.theme.border_color};
        border-radius: 100px;
      }
  }   
```

### 해결책
여러 해결책을 시도해 봤으나, 가장 마음에 드는 방식은 아래와 같이 
모바일 범위를 벗어날 경우에만 스크롤 바를 커스텀으로 부여하는 것이였습니다.

```tsx
    @media not all and (max-width: ${MOBILE}px) {
      * {
        &::-webkit-scrollbar {
          width: 0.4rem;
        }
        &::-webkit-scrollbar-thumb {
          background-color: ${(props) => props.theme.border_color};
          border-radius: 100px;
        }
      }
    }
```
이때의 단점은 웹에서 화면을 줄일 경우 클래식 스크롤바가 그대로 출력된다는 것인데,
어차피 웹에서 작은 화면을 볼 일은 없을 것으로 추측하여 문제가 없을 것이라고 판단하였습니다.
![image](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/90549862/36d5e1f1-1b51-4f11-b615-fe9a8e85623a)

이외에도 스크롤바를 아예 none으로 주는 방식도 있었는데
아예 보이지 않는 것은 사용자 입장에서 가시적이지 않을 것 같아서 제외하였습니다.