### PR TITLE
[#203] SharedBundleCard 컴포넌트 구현 v1.1.1

### DIFF
--- a/src/components/SharedBundle/SharedBundleCard/SharedBundleCard.const.ts
+++ b/src/components/SharedBundle/SharedBundleCard/SharedBundleCard.const.ts
@@ -1,0 +1,4 @@
+export const SHARED_BUNDLE_CARD = {
+  SUCCESS_SCRAPE_NOTIFY: '꾸러미가 스크랩되었습니다.',
+  FAIL_SCRAPE_NOTIFY: '꾸러미 스크랩을 실패하였습니다.',
+};

--- a/src/components/SharedBundle/SharedBundleCard/SharedBundleCard.style.ts
+++ b/src/components/SharedBundle/SharedBundleCard/SharedBundleCard.style.ts
@@ -34,4 +34,8 @@ export const ClickContent = styled.div`
   right: 0;
   margin: 0 2rem;
   gap: 2rem;
+  @media screen and (max-width: ${MOBILE}px) {
+    margin: 0 0.5rem;
+    gap: 0;
+  }
 `;

--- a/src/components/SharedBundle/SharedBundleCard/SharedBundleCard.style.ts
+++ b/src/components/SharedBundle/SharedBundleCard/SharedBundleCard.style.ts
@@ -4,8 +4,7 @@ import { MOBILE_FONT_SIZE, WEB_FONT_SIZE } from '@/constants';
 import { FONT_MEDIUM, MOBILE, MOBILE_MIN } from '@/constants';
 
 export const SharedBundleCardWrapper = styled.div`
-  width: 90%;
-  max-width: 80rem;
+  width: 100%;
   min-width: 28rem;
 `;
 
@@ -18,12 +17,12 @@ export const BundleTitle = styled.div`
   color: ${({ theme }) => theme.primary_white_text_color};
 
   @media screen and (max-width: ${MOBILE}px) {
-    font-size: ${WEB_FONT_SIZE};
+    font-size: ${WEB_FONT_SIZE}rem;
     padding: 1.5rem;
   }
 
   @media screen and (max-width: ${MOBILE_MIN}px) {
-    font-size: ${MOBILE_FONT_SIZE};
+    font-size: ${MOBILE_FONT_SIZE}rem;
     padding: 1rem;
   }
 `;

--- a/src/components/SharedBundle/SharedBundleCard/SharedBundleCard.style.ts
+++ b/src/components/SharedBundle/SharedBundleCard/SharedBundleCard.style.ts
@@ -32,6 +32,6 @@ export const ClickContent = styled.div`
   align-items: center;
   position: absolute;
   right: 0;
-  margin: 0 1rem;
-  gap: 1rem;
+  margin: 0 2rem;
+  gap: 2rem;
 `;

--- a/src/components/SharedBundle/SharedBundleCard/SharedBundleCard.tsx
+++ b/src/components/SharedBundle/SharedBundleCard/SharedBundleCard.tsx
@@ -14,6 +14,7 @@ import { Direction } from '@/types/dropdown';
 import { handleCopyClipBoard } from '@/utils/copyClip';
 
 import SharedBundleDropDown from '../SharedBundleDropDown';
+import { SHARED_BUNDLE_CARD } from './SharedBundleCard.const';
 import {
   BundleTitle,
   ClickContent,
@@ -48,12 +49,12 @@ const SharedBundleCard = ({
     if (result) {
       notify({
         type: 'success',
-        text: '꾸러미가 스크랩되었습니다.',
+        text: SHARED_BUNDLE_CARD.SUCCESS_SCRAPE_NOTIFY,
       });
     } else {
       notify({
         type: 'error',
-        text: '꾸러미 스크랩을 실패하였습니다.',
+        text: SHARED_BUNDLE_CARD.FAIL_SCRAPE_NOTIFY,
       });
     }
   };

--- a/src/components/SharedBundle/SharedBundleCard/SharedBundleCard.tsx
+++ b/src/components/SharedBundle/SharedBundleCard/SharedBundleCard.tsx
@@ -40,27 +40,6 @@ const SharedBundleCard = ({
   const { triggerId, isShow, setIsShow, toggleDropDown, closeDropDown } =
     useDropDown('sharedBundle-dropdown');
 
-  const toastClipBoard = () => {
-    notify({
-      type: 'success',
-      text: '클립보드에 링크가 복사되었습니다.',
-    });
-  };
-
-  const toastAddBundle = () => {
-    notify({
-      type: 'success',
-      text: '꾸러미가 스크랩되었습니다.',
-    });
-  };
-
-  const toastErrorAddBundle = () => {
-    notify({
-      type: 'error',
-      text: '꾸러미 스크랩을 실패하였습니다.',
-    });
-  };
-
   const handleOpenDropdown = (e: React.MouseEvent) => {
     toggleDropDown(e);
   };
@@ -68,9 +47,15 @@ const SharedBundleCard = ({
   const handleScrapBundle = async () => {
     const result = await scrapeBundle(bundleId);
     if (result) {
-      toastAddBundle();
+      notify({
+        type: 'success',
+        text: '꾸러미가 스크랩되었습니다.',
+      });
     } else {
-      toastErrorAddBundle();
+      notify({
+        type: 'error',
+        text: '꾸러미 스크랩을 실패하였습니다.',
+      });
     }
   };
 
@@ -101,7 +86,6 @@ const SharedBundleCard = ({
                 $hoverIconColor={theme.symbol_secondary_color}
                 onClick={() => {
                   handleCopyClipBoard(SERVICE_URL, CURRENT_URL);
-                  toastClipBoard();
                 }}
               >
                 <RiFileCopyLine id={triggerId} />

--- a/src/components/SharedBundle/SharedBundleCard/SharedBundleCard.tsx
+++ b/src/components/SharedBundle/SharedBundleCard/SharedBundleCard.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { RiFileCopyLine, RiShareLine } from 'react-icons/ri';
 import { useLocation } from 'react-router-dom';
 import { useTheme } from 'styled-components';
@@ -9,6 +10,7 @@ import { notify } from '@/hooks/toast';
 import useDropDown from '@/hooks/useDropDown';
 import useResize from '@/hooks/useResize';
 import { scrapeBundle } from '@/services/bundles';
+import { Direction } from '@/types/dropdown';
 import { handleCopyClipBoard } from '@/utils/copyClip';
 
 import SharedBundleDropDown from '../SharedBundleDropDown';
@@ -37,12 +39,9 @@ const SharedBundleCard = ({
   const location = useLocation();
   const SERVICE_URL = window.location.host;
   const CURRENT_URL = location.pathname;
+  const [direction, setDirection] = useState<Direction>('bottom-left');
   const { triggerId, isShow, setIsShow, toggleDropDown, closeDropDown } =
     useDropDown('sharedBundle-dropdown');
-
-  const handleOpenDropdown = (e: React.MouseEvent) => {
-    toggleDropDown(e);
-  };
 
   const handleScrapBundle = async () => {
     const result = await scrapeBundle(bundleId);
@@ -57,6 +56,18 @@ const SharedBundleCard = ({
         text: '꾸러미 스크랩을 실패하였습니다.',
       });
     }
+  };
+
+  const handleOpenDropdown = (e: React.MouseEvent) => {
+    if ((e.target as Element).id === triggerId) {
+      if (e.clientY > window.innerHeight / 2) {
+        setDirection('top-left');
+      } else {
+        setDirection('bottom-left');
+      }
+    }
+
+    toggleDropDown(e);
   };
 
   return (
@@ -112,7 +123,7 @@ const SharedBundleCard = ({
                 setIsShow={setIsShow}
                 closeDropDown={closeDropDown}
                 onAddBundle={handleScrapBundle}
-                direction="bottom-left"
+                direction={direction}
               />
             </ClickContent>
           )}

--- a/src/components/SharedBundle/SharedBundleCard/SharedBundleCard.type.ts
+++ b/src/components/SharedBundle/SharedBundleCard/SharedBundleCard.type.ts
@@ -1,4 +1,5 @@
 export interface SharedBundleCardProps
   extends React.HTMLAttributes<HTMLSpanElement> {
   bundleName: string;
+  bundleId: number;
 }


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용
sharedBundleDropDown 버전이 바뀌면서 코드수정을 하였습니다.
추후에 바뀐 sharedBundleDropDown도 수정해서 올리겠습니다.
# 📷스크린샷(필요 시)

# ✨PR Point
- 꾸러미의 id값을 받는 props를 추가했습니다. 타입은 `number`타입입니다.
- toast 훅을 이용하여 `alert`를 대신했습니다.