### PR TITLE
[#209] SharedBundleDropdown 구현 v1.1.0

### DIFF
--- a/src/components/SharedBundle/SharedBundleDropDown/SharedBundleDropDown.style.ts
+++ b/src/components/SharedBundle/SharedBundleDropDown/SharedBundleDropDown.style.ts
@@ -1,7 +1,0 @@
-import styled from 'styled-components';
-
-export const SharedBundleDropDownWrapper = styled.div<{ $width: string }>`
-  position: absolute;
-  bottom: 0;
-  right: ${({ $width }) => $width};
-`;

--- a/src/components/SharedBundle/SharedBundleDropDown/SharedBundleDropDown.tsx
+++ b/src/components/SharedBundle/SharedBundleDropDown/SharedBundleDropDown.tsx
@@ -4,37 +4,47 @@ import { useLocation } from 'react-router-dom';
 
 import DropDown from '@/components/common/DropDown';
 import IconWrapper from '@/components/common/IconWrapper';
+import { notify } from '@/hooks/toast';
 import { handleCopyClipBoard } from '@/utils/copyClip';
 
-import { SharedBundleDropDownWrapper } from './SharedBundleDropDown.style';
 import { SharedBundleDropDownProps } from './SharedBundleDropDown.type';
 
 /**
  * @summary 사용법    <SharedBundleDropDown
-          isDropDownShow={isDropDownShow}
-          setIsDropDownShow={setIsDropDownShow}
-          triggerId="dropdown1-btn"
-          width="14rem"
-        />
-        SharedBundleDropDown는 position: absolute 속성이 있습니다.
-        SharedBundleDropDown 사용하는 부모컴포넌트에 무조건 position: 'relative'를 주어야 합니다. 
+          bundleId={1}
+          isShow={isShow}
+          setIsShow={setIsShow}
+          closeDropDown={closeDropDown}
+          direction="bottom-right"
+          onAddBundle={() => console.log('test')}
+        /> 
  * @description SharedBundleDropDown 컴포넌트
- * @param isDropDownShow 필수) SharedBundleDropDown가 보여지는 유무를 나타내는 상태값입니다.
- * @param setIsDropDownShow 필수) isDropDownShow 상태값을 set하는 함수입니다.
- * @param triggerId 필수) 드롭다운 컴포넌트가 isShow=true가 되도록 해주는 HTMLElement의 id입니다.
- * @param width 선택) width값으로 DropDown의 크기를 설정합니다. string 타입이며 기본값으로 12rem이 들어갑니다.
+ * @param bundleId 필수) 꾸러미의 고유한 id값입니다. number타입입니다.
+ * @param isShow 필수) SharedBundleDropDown가 보여지는 유무를 나타내는 상태값입니다.
+ * @param setIsShow 필수) isShow 상태값을 set하는 함수입니다.
+ * @param closeDropDown 필수) 드롭다운의 닫히는 함수를 받습니다.
+ * @param direction 필수) 드롭다운이 위치할 위치를 받습니다.
+ * @param onAddBundle 필수) 꾸러미를 추가할 때 호출되는 함수입니다.
  * @returns
  */
 
 const SharedBundleDropDown = ({
-  isDropDownShow,
-  setIsDropDownShow,
-  triggerId,
-  width = '12rem',
+  isShow,
+  setIsShow,
+  closeDropDown,
+  direction,
+  onAddBundle,
 }: SharedBundleDropDownProps) => {
   const location = useLocation();
   const SERVICE_URL = window.location.host;
   const CURRENT_URL = location.pathname;
+
+  const toastClipBoard = () => {
+    notify({
+      type: 'success',
+      text: '클립보드에 링크가 복사되었습니다.',
+    });
+  };
 
   const OPTIONS = [
     {
@@ -46,8 +56,8 @@ const SharedBundleDropDown = ({
         </IconWrapper>
       ),
       handler: () => {
-        console.log('꾸러미가 추가되었습니다'); // 추후 실제 api 연동 과정이 필요
-        setIsDropDownShow(!isDropDownShow);
+        onAddBundle();
+        setIsShow(false);
       },
     },
     {
@@ -60,23 +70,28 @@ const SharedBundleDropDown = ({
       ),
       handler: () => {
         handleCopyClipBoard(SERVICE_URL, CURRENT_URL);
-        setIsDropDownShow(!isDropDownShow);
+        toastClipBoard();
+        setIsShow(false);
       },
     },
   ];
 
   return (
-    <SharedBundleDropDownWrapper $width={width}>
-      <DropDown
-        mode="normal"
-        width={width}
-        height="fit-content"
-        options={OPTIONS}
-        isShow={isDropDownShow}
-        setIsShow={setIsDropDownShow}
-        triggerId={triggerId}
-      />
-    </SharedBundleDropDownWrapper>
+    <>
+      <div>
+        <DropDown
+          mode="normal"
+          width={12}
+          optionHeight={5}
+          height={10}
+          closeDropDown={closeDropDown}
+          options={OPTIONS}
+          isShow={isShow}
+          setIsShow={setIsShow}
+          direction={direction}
+        />
+      </div>
+    </>
   );
 };
 

--- a/src/components/SharedBundle/SharedBundleDropDown/SharedBundleDropDown.type.ts
+++ b/src/components/SharedBundle/SharedBundleDropDown/SharedBundleDropDown.type.ts
@@ -1,6 +1,10 @@
+import { Direction } from '@/types/dropdown';
+
 export interface SharedBundleDropDownProps {
-  isDropDownShow: boolean;
-  setIsDropDownShow: (state: boolean) => void;
-  triggerId: string;
-  width?: string;
+  isShow: boolean;
+  setIsShow: (state: boolean) => void;
+  closeDropDown: (e: Event) => void;
+  direction: Direction;
+  onAddBundle: () => void;
+  bundleId: number;
 }

--- a/src/utils/copyClip.ts
+++ b/src/utils/copyClip.ts
@@ -1,7 +1,6 @@
 export const handleCopyClipBoard = async (host: string, pathname: string) => {
   try {
     await navigator.clipboard.writeText(`${host}${pathname}`);
-    alert('클립보드에 링크가 복사되었습니다.');
   } catch (err) {
     console.log(err);
   }


### PR DESCRIPTION
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용
DropDown의 버전이 올라가면서 자연스럽게 sharedBundleDropDown도 버전이 업데이트되었습니다.
# 📷스크린샷(필요 시)
<img width="589" alt="스크린샷 2024-03-05 오후 5 44 55" src="https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/81172451/6f4e8c16-c48f-41f4-a84a-16f4bf887774">

# ✨PR Point
달라진거는 많지않고 props가 조금 달라졌습니다.
- `bundleId` 필수) 꾸러미의 고유한 id값입니다. number타입입니다.
- `isShow` 필수) SharedBundleDropDown가 보여지는 유무를 나타내는 상태값입니다.
- `setIsShow` 필수) isShow 상태값을 set하는 함수입니다.
- `closeDropDown` 필수) 드롭다운의 닫히는 함수를 받습니다.
- `direction` 필수) 드롭다운이 위치할 위치를 받습니다.
- `onAddBundle` 필수) 꾸러미를 추가할 때 호출되는 함수입니다.

### 테스트코드
```js
import Button from '@/components/common/Button';
import SharedBundleDropDown from '@/components/SharedBundle/SharedBundleDropDown';
import useDropDown from '@/hooks/useDropDown';

const TestPage = () => {
  // 요기다가 하시면 됩니다
  const { triggerId, isShow, setIsShow, toggleDropDown, closeDropDown } =
    useDropDown('trigger-button');

  const handleClick = (e: React.MouseEvent) => {
    toggleDropDown(e);
  };
  return (
    <>
      <Button
        onClick={handleClick}
        text="버튼 테스트"
        id={triggerId}
        style={{ position: 'relative' }}
      >
        <SharedBundleDropDown
          bundleId={1}
          isShow={isShow}
          setIsShow={setIsShow}
          closeDropDown={closeDropDown}
          direction="bottom-right"
          onAddBundle={() => console.log('test')}
        />
      </Button>
    </>
  );
};

export default TestPage;

```