### PR TITLE
[#196] TagFilter 컴포넌트 구현 v1.2.1

### DIFF
--- a/src/components/common/TagFilter/TagFilter.style.tsx
+++ b/src/components/common/TagFilter/TagFilter.style.tsx
@@ -11,6 +11,7 @@ export const TagItemWrapper = styled(Row)`
   width: 95%;
   height: 100%;
   gap: 0.5rem;
+  user-select: none;
   @media screen and (max-width: ${MOBILE}px) {
     width: 100%;
     padding: 1rem;

--- a/src/components/common/TagFilter/TagFilter.tsx
+++ b/src/components/common/TagFilter/TagFilter.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 
+import { notify } from '@/hooks/toast';
 import useResize from '@/hooks/useResize';
 import { Tag } from '@/types';
 
@@ -30,6 +31,7 @@ const TagFilter = ({
   tagList,
   selectedTags,
   setSelectedTags,
+  isLimit = false,
   ...props
 }: TagFilterProps) => {
   const isSelectedTag = useCallback(
@@ -42,6 +44,14 @@ const TagFilter = ({
 
   const toggleActiveName = useCallback(
     (tag: Tag) => {
+      if (isLimit && selectedTags.length >= 3 && !isSelectedTag(tag)) {
+        notify({
+          type: 'warning',
+          text: '태그는 3개까지만 선택할 수 있습니다!',
+        });
+        return;
+      }
+
       if (isSelectedTag(tag)) {
         setSelectedTags(
           selectedTags.filter((selectedTag) => selectedTag.id !== tag.id)
@@ -50,7 +60,7 @@ const TagFilter = ({
         setSelectedTags([...selectedTags, tag]);
       }
     },
-    [isSelectedTag, selectedTags, setSelectedTags]
+    [isSelectedTag, selectedTags, setSelectedTags, isLimit]
   );
 
   return (

--- a/src/components/common/TagFilter/TagFilter.tsx
+++ b/src/components/common/TagFilter/TagFilter.tsx
@@ -19,11 +19,13 @@ import { TagFilterProps } from './TagFilter.type';
         tagList={tagList}
         selectedTags={selectedTags}
         setSelectedTags={setSelectedTags}
+         isLimit={true}
       />
  * @description 공통 TagFilter 컴포넌트
  * @param setSelectedTags 필수) TagFilter에서 선택한 태그들입니다.
  * @param selectedTags 필수) TagFilter에서 초기 선택된 태그를 설정하기 위한 prop입니다.
  * @param tagList 필수) 태그들의 정보를 받아옵니다.
+ * @param isLimit 선택) 선택하는 태그를 3개만 선택할수있도록 제한하는 옵션입니다. boolean값이고 default는 false입니다.
  * @returns
  */
 

--- a/src/components/common/TagFilter/TagFilter.type.ts
+++ b/src/components/common/TagFilter/TagFilter.type.ts
@@ -4,4 +4,5 @@ export interface TagFilterProps extends React.HTMLAttributes<HTMLDivElement> {
   tagList: Tag[];
   setSelectedTags: (tags: Tag[]) => void;
   selectedTags: Tag[];
+  isLimit?: boolean;
 }


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용
TagFilter 컴포넌트에 isLimit props를 추가했습니다.
# 📷스크린샷(필요 시)
<img width="932" alt="image" src="https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/81172451/38ff5d72-2c02-4051-8acc-a027e8c9b93a">

# ✨PR Point
 `isLimit` - 선택하는 태그를 3개만 선택할수있도록 제한하는 옵션입니다. boolean값이고 default는 false입니다.
- 3개를 넘어서 4개를 클릭하는 순간 경고메세지가 뜨고 4번째로 누른 태그는 다시  안눌린상태로 돌아갑니다.
- 그리고 필터에 있는 태그를 여러번 클릭하면  파란박스가 생기는것을   `user-select: none`로 막아주었습니다.
- 지금 구현하시면서 요게 필요하면 풀 땡기고 사용하시면 될거같습니다 !