### PR TITLE
[#239] API 토큰 로직 관련 hotfix

### DIFF
--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -54,6 +54,7 @@ axiosInstance.interceptors.response.use(
         window.alert('토큰이 만료되어 자동으로 로그아웃 되었습니다.');
       }
     } else if (status == 400 || status == 404 || status == 409) {
+      removeItem('refresh-token');
       window.alert(msg);
     }
     return Promise.reject(error);


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용
401에러가 아닌 400에러가 오는 경우 로그아웃 처리가 정상적으로 이루어지지 않고 있습니다.
에러 메세지가 구분을 못해서 그런 것 같은데, 일단 재로그인 반영하는 로직을 한 번 더 살펴봐야 할 것 같고
그전에 일단 모든 에러 케이스에서 로그아웃을 시키는 동작이 옳다고 판단되어 일단 핫픽스 요소로 올립니다 😢 
일단 요 부분 간단하게 머지해두고 다들 배포 끝나시면 같이 확인해봐요..!