### PR TITLE
[#250] 공유된 꾸러미 페이지 구현 v1.2.0

### DIFF
--- a/src/pages/SharedPage/Shared.const.ts
+++ b/src/pages/SharedPage/Shared.const.ts
@@ -1,4 +1,21 @@
-export const SelectorConstants = {
-  RECENT_SORT_TEXT: '최근순',
-  POPULAR_SORT_TEXT: '스크랩 순',
+export const SharedHookConstants = {
+  SHARED_SEARCH_REGISTER: 'SharedSearch',
+  SHARED_SELECTOR_CONTENT: ['최근순', '스크랩 순'],
+  SHARED_DYNAMIC_QUERY_KEY: (
+    keyword: string,
+    filteredTags: object | string,
+    isRecent: string
+  ) => 'BundleSearch' + keyword + filteredTags + isRecent,
+  SHARED_TAG_FILTERING: (tags: number[]) =>
+    tags.length === 0 ? [] : tags.join(', '),
+};
+
+export const SharedTextConstants = {
+  SHARED_ERROR_MESSAGE: '죄송합니다! 에러가 발생했습니다!',
+  SHARED_INFINITY_LOADING: '다음 페이지 불러오는 중...',
+
+  SHARED_NEXT_PAGE_BUTTON: '다음 페이지 불러오기',
+  SHARED_NEXT_PAGE_NONE_BUTTON: '마지막 꾸러미에요!',
+
+  SHARED_SEARCH_NONE: '검색된 결과가 없습니다.',
 };

--- a/src/pages/SharedPage/Shared.style.ts
+++ b/src/pages/SharedPage/Shared.style.ts
@@ -1,42 +1,40 @@
 import styled from 'styled-components';
 
-import { MOBILE } from '@/constants';
+import { MOBILE, MOBILE_FONT_SIZE } from '@/constants';
+import { Col, Row } from '@/styles/globalStyles';
 
-export const SharedWrapper = styled.div`
+export const SharedWrapper = styled(Col)`
   width: 70%;
-  display: flex;
-  flex-direction: column;
   margin: 0 auto;
   gap: 3rem;
+
   @media screen and (max-width: ${MOBILE}px) {
     width: 90%;
-    gap: 1rem;
+    gap: 1.5rem;
   }
 `;
 
-export const TagFilterWrapper = styled.div`
+export const TagFilterWrapper = styled(Row)`
   width: 100%;
   margin: 5rem auto;
-  display: flex;
   justify-content: center;
+
   @media screen and (max-width: ${MOBILE}px) {
     margin: 2rem auto;
   }
 `;
 
-export const SearchWrapper = styled.div`
+export const SearchWrapper = styled(Row)`
   width: 100%;
-  display: flex;
-  margin: 0 auto;
-  gap: 2rem;
-  justify-content: start;
+  height: 4rem;
+
   @media screen and (max-width: ${MOBILE}px) {
-    flex-direction: column;
+    height: 3rem;
   }
 `;
 
-export const SelectorWrapper = styled.div`
-  display: flex;
+export const SelectorWrapper = styled(Row)`
+  margin: 1rem 0;
   justify-content: end;
 `;
 
@@ -49,7 +47,40 @@ export const CardWrapper = styled.div`
   grid-template-columns: repeat(2, 1fr);
   box-sizing: border-box;
   justify-items: center;
+
   @media screen and (max-width: 1000px) {
     grid-template-columns: repeat(1, 1fr);
   }
+`;
+
+export const SharedSearchNone = styled.div`
+  font-size: 1.6rem;
+  color: ${({ theme }) => theme.primary_color};
+`;
+
+export const SharedFooterWrapper = styled(Col)`
+  width: 70%;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+  box-sizing: border-box;
+`;
+
+export const SharedInfiniteMessage = styled(Col)`
+  margin: 0 auto;
+  color: ${({ theme }) => theme.primary_color};
+  align-items: center;
+  font-size: 1.8rem;
+  padding: 2rem 1rem;
+  box-sizing: border-box;
+
+  @media screen and (max-width: ${MOBILE}px) {
+    font-size: ${MOBILE_FONT_SIZE}rem;
+    padding: 1rem 0.5rem;
+  }
+`;
+
+export const SharedSearchError = styled(SharedSearchNone)`
+  display: flex;
+  width: 100%;
+  justify-content: center;
 `;

--- a/src/pages/SharedPage/Shared.style.ts
+++ b/src/pages/SharedPage/Shared.style.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { MOBILE, MOBILE_FONT_SIZE } from '@/constants';
+import { MOBILE, MOBILE_FONT_SIZE, WEB_FONT_SIZE } from '@/constants';
 import { Col, Row } from '@/styles/globalStyles';
 
 export const SharedWrapper = styled(Col)`
@@ -60,9 +60,15 @@ export const Section2 = styled.div`
   row-gap: 2rem;
 `;
 
-export const SharedSearchNone = styled.div`
-  font-size: 1.6rem;
+export const SharedSearchNone = styled(Row)`
+  align-items: center;
+  justify-content: center;
+  font-size: ${WEB_FONT_SIZE}rem;
   color: ${({ theme }) => theme.primary_color};
+
+  @media screen and (max-width: ${MOBILE}px) {
+    font-size: ${MOBILE_FONT_SIZE}rem;
+  }
 `;
 
 export const SharedFooterWrapper = styled(Col)`

--- a/src/pages/SharedPage/Shared.style.ts
+++ b/src/pages/SharedPage/Shared.style.ts
@@ -58,6 +58,9 @@ export const Section1 = styled.div`
 export const Section2 = styled.div`
   display: grid;
   row-gap: 2rem;
+  @media screen and (max-width: ${MOBILE}px) {
+    margin-top: 2rem;
+  }
 `;
 
 export const SharedSearchNone = styled(Row)`

--- a/src/pages/SharedPage/Shared.style.ts
+++ b/src/pages/SharedPage/Shared.style.ts
@@ -39,18 +39,25 @@ export const SelectorWrapper = styled(Row)`
 `;
 
 export const CardWrapper = styled.div`
-  width: 100%;
   display: grid;
-  margin: 0 auto;
-  grid-row-gap: 2rem;
-  grid-column-gap: 7rem;
-  grid-template-columns: repeat(2, 1fr);
-  box-sizing: border-box;
-  justify-items: center;
+  -webkit-box-align: start;
+  align-items: start;
+  column-gap: 7rem;
+  grid-template-columns: repeat(2, minmax(0px, 1fr));
 
   @media screen and (max-width: 1000px) {
     grid-template-columns: repeat(1, 1fr);
   }
+`;
+
+export const Section1 = styled.div`
+  display: grid;
+  row-gap: 2rem;
+`;
+
+export const Section2 = styled.div`
+  display: grid;
+  row-gap: 2rem;
 `;
 
 export const SharedSearchNone = styled.div`

--- a/src/pages/SharedPage/Shared.tsx
+++ b/src/pages/SharedPage/Shared.tsx
@@ -15,6 +15,8 @@ import { useSearchBundlesInfinite } from './Shared.hook';
 import {
   CardWrapper,
   SearchWrapper,
+  Section1,
+  Section2,
   SelectorWrapper,
   SharedFooterWrapper,
   SharedInfiniteMessage,
@@ -85,29 +87,58 @@ const Shared = () => {
         </SelectorWrapper>
         {isFetching && <Spinner />}
         <CardWrapper>
-          {infinityData &&
-            infinityData.pages.map((pageList) => {
-              return pageList?.content.map(
-                (bundle: BundlesBasic) =>
-                  bundle.shareType === 'PUBLIC' && (
-                    <BundleCard
-                      key={bundle.id}
-                      bundleName={bundle.name}
-                      hashTags={bundle.tags}
-                      id={bundle.id}
-                      subscribedCount={bundle.scrapeCount}
-                      isHot={bundle.isHot}
-                    />
-                  )
-              );
-            })}
-          {!isFetching &&
-            !isFetchingNextPage &&
-            infinityData?.pages[0]?.content.length === 0 && (
-              <SharedSearchNone>
-                {SharedTextConstants.SHARED_SEARCH_NONE}
-              </SharedSearchNone>
-            )}
+          <Section1>
+            {infinityData &&
+              infinityData.pages.map((pageList) => {
+                return pageList?.content.map(
+                  (bundle: BundlesBasic, index) =>
+                    bundle.shareType === 'PUBLIC' &&
+                    index % 2 === 0 && (
+                      <BundleCard
+                        key={bundle.id}
+                        bundleName={bundle.name}
+                        hashTags={bundle.tags}
+                        id={bundle.id}
+                        subscribedCount={bundle.scrapeCount}
+                        isHot={bundle.isHot}
+                      />
+                    )
+                );
+              })}
+            {!isFetching &&
+              !isFetchingNextPage &&
+              infinityData?.pages[0]?.content.length === 0 && (
+                <SharedSearchNone>
+                  {SharedTextConstants.SHARED_SEARCH_NONE}
+                </SharedSearchNone>
+              )}
+          </Section1>
+          <Section2>
+            {infinityData &&
+              infinityData.pages.map((pageList) => {
+                return pageList?.content.map(
+                  (bundle: BundlesBasic, index) =>
+                    bundle.shareType === 'PUBLIC' &&
+                    index % 2 === 1 && (
+                      <BundleCard
+                        key={bundle.id}
+                        bundleName={bundle.name}
+                        hashTags={bundle.tags}
+                        id={bundle.id}
+                        subscribedCount={bundle.scrapeCount}
+                        isHot={bundle.isHot}
+                      />
+                    )
+                );
+              })}
+            {!isFetching &&
+              !isFetchingNextPage &&
+              infinityData?.pages[0]?.content.length === 0 && (
+                <SharedSearchNone>
+                  {SharedTextConstants.SHARED_SEARCH_NONE}
+                </SharedSearchNone>
+              )}
+          </Section2>
         </CardWrapper>
 
         <SharedFooterWrapper>

--- a/src/pages/SharedPage/Shared.tsx
+++ b/src/pages/SharedPage/Shared.tsx
@@ -2,31 +2,37 @@ import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import BundleCard from '@/components/common/BundleCard';
+import Button from '@/components/common/Button';
 import SearchBar from '@/components/common/SearchBar';
 import Selector from '@/components/common/Selector';
+import Spinner from '@/components/common/Spinner';
 import TagFilter from '@/components/common/TagFilter';
 import { useFetchTags } from '@/hooks/useFetchTags';
-import { Tag } from '@/types';
+import { BundlesBasic, SortingType, Tag } from '@/types';
 
-import { SelectorConstants } from './Shared.const';
-import { useLatestBundles, usePopularBundles } from './Shared.hook';
+import { SharedHookConstants, SharedTextConstants } from './Shared.const';
+import { useSearchBundlesInfinite } from './Shared.hook';
 import {
   CardWrapper,
   SearchWrapper,
   SelectorWrapper,
+  SharedFooterWrapper,
+  SharedInfiniteMessage,
+  SharedSearchError,
+  SharedSearchNone,
   SharedWrapper,
   TagFilterWrapper,
 } from './Shared.style';
 
 const Shared = () => {
-  const [isRecent, setIsRecent] = useState<boolean>(true);
+  const [isRecent, setIsRecent] = useState<SortingType>('LATEST');
   const { data: tags } = useFetchTags();
   const [selectedTags, setSelectedTags] = useState<Tag[]>([]);
   const [searchedBundles, setSearchedBundles] = useState<string>('');
 
   const tagsId = selectedTags.map((tag) => tag.id);
   const methods = useForm({ mode: 'onSubmit' });
-  const REGISTER = 'searchBundle';
+  const REGISTER = SharedHookConstants.SHARED_SEARCH_REGISTER;
 
   const onSubmit = () => {
     const searchedBundles = methods.getValues(REGISTER).trim();
@@ -37,9 +43,14 @@ const Shared = () => {
     }
   };
 
-  const { data: latestBundles } = useLatestBundles(tagsId, searchedBundles);
-
-  const { data: popularBundles } = usePopularBundles(tagsId, searchedBundles);
+  const {
+    data: infinityData,
+    isFetching,
+    isFetchingNextPage,
+    isError,
+    hasNextPage,
+    fetchNextPage,
+  } = useSearchBundlesInfinite(tagsId, searchedBundles, isRecent);
 
   return (
     <>
@@ -62,51 +73,73 @@ const Shared = () => {
         </SearchWrapper>
         <SelectorWrapper>
           <Selector
-            isState={isRecent}
-            setIsState={setIsRecent}
+            isState={isRecent === 'LATEST'}
+            setIsState={(isRecent) =>
+              setIsRecent(isRecent ? 'LATEST' : 'POPULAR')
+            }
             content={[
-              SelectorConstants.RECENT_SORT_TEXT,
-              SelectorConstants.POPULAR_SORT_TEXT,
+              SharedHookConstants.SHARED_SELECTOR_CONTENT[0],
+              SharedHookConstants.SHARED_SELECTOR_CONTENT[1],
             ]}
           />
         </SelectorWrapper>
+        {isFetching && <Spinner />}
         <CardWrapper>
-          {isRecent ? (
-            latestBundles?.content.length !== 0 ? (
-              latestBundles?.content.map(
-                (bundle) =>
+          {infinityData &&
+            infinityData.pages.map((pageList) => {
+              return pageList?.content.map(
+                (bundle: BundlesBasic) =>
                   bundle.shareType === 'PUBLIC' && (
                     <BundleCard
                       key={bundle.id}
-                      id={bundle.id}
                       bundleName={bundle.name}
                       hashTags={bundle.tags}
-                      isHot={bundle.isHot}
+                      id={bundle.id}
                       subscribedCount={bundle.scrapeCount}
+                      isHot={bundle.isHot}
                     />
                   )
-              )
-            ) : (
-              <h1>검색된 결과가 없습니다.</h1>
-            )
-          ) : popularBundles?.content.length !== 0 ? (
-            popularBundles?.content.map(
-              (bundle) =>
-                bundle.shareType === 'PUBLIC' && (
-                  <BundleCard
-                    key={bundle.id}
-                    id={bundle.id}
-                    bundleName={bundle.name}
-                    hashTags={bundle.tags}
-                    isHot={bundle.isHot}
-                    subscribedCount={bundle.scrapeCount}
-                  />
-                )
-            )
-          ) : (
-            <h1>검색된 결과가 없습니다.</h1>
-          )}
+              );
+            })}
+          {!isFetching &&
+            !isFetchingNextPage &&
+            infinityData?.pages[0]?.content.length === 0 && (
+              <SharedSearchNone>
+                {SharedTextConstants.SHARED_SEARCH_NONE}
+              </SharedSearchNone>
+            )}
         </CardWrapper>
+
+        <SharedFooterWrapper>
+          {hasNextPage && !isFetchingNextPage && (
+            <Button
+              width="100%"
+              height="3rem"
+              onClick={() => fetchNextPage()}
+              text={SharedTextConstants.SHARED_NEXT_PAGE_BUTTON}
+            />
+          )}
+          {infinityData?.pages[0]?.content.length &&
+          !hasNextPage &&
+          !isFetchingNextPage ? (
+            <Button
+              width="100%"
+              height="3rem"
+              disabled
+              text={SharedTextConstants.SHARED_NEXT_PAGE_NONE_BUTTON}
+            />
+          ) : null}
+          {isFetching && isFetchingNextPage && (
+            <SharedInfiniteMessage>
+              {SharedTextConstants.SHARED_INFINITY_LOADING}
+            </SharedInfiniteMessage>
+          )}
+        </SharedFooterWrapper>
+        {isError && (
+          <SharedSearchError>
+            {SharedTextConstants.SHARED_ERROR_MESSAGE}
+          </SharedSearchError>
+        )}
       </SharedWrapper>
     </>
   );

--- a/src/pages/SharedPage/Shared.tsx
+++ b/src/pages/SharedPage/Shared.tsx
@@ -105,13 +105,6 @@ const Shared = () => {
                     )
                 );
               })}
-            {!isFetching &&
-              !isFetchingNextPage &&
-              infinityData?.pages[0]?.content.length === 0 && (
-                <SharedSearchNone>
-                  {SharedTextConstants.SHARED_SEARCH_NONE}
-                </SharedSearchNone>
-              )}
           </Section1>
           <Section2>
             {infinityData &&
@@ -131,16 +124,15 @@ const Shared = () => {
                     )
                 );
               })}
-            {!isFetching &&
-              !isFetchingNextPage &&
-              infinityData?.pages[0]?.content.length === 0 && (
-                <SharedSearchNone>
-                  {SharedTextConstants.SHARED_SEARCH_NONE}
-                </SharedSearchNone>
-              )}
           </Section2>
         </CardWrapper>
-
+        {!isFetching &&
+          !isFetchingNextPage &&
+          infinityData?.pages[0]?.content.length === 0 && (
+            <SharedSearchNone>
+              {SharedTextConstants.SHARED_SEARCH_NONE}
+            </SharedSearchNone>
+          )}
         <SharedFooterWrapper>
           {hasNextPage && !isFetchingNextPage && (
             <Button


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용
공유된 페이지를 구현하였습니다.
# 📷스크린샷(필요 시)
<img width="1394" alt="image" src="https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/81172451/aafa4d64-9a52-4ff8-bf4a-2bf1ab84386f">

# ✨PR Point
- 다음 페이지 더 불러오기를 추가하였습니다.
- 꾸러미의 제목이 아이템 높이에 맞게 높이를 지정하였습니다.
- 1.1.0 버전의 훅을 수정하였습니다. (더 불러오기를 위해서 `useQuery` => `useInfiniteQuery` 변경)