### PR TITLE
[#266] 꾸러미, 꾸러미 상세 페이지 레이아웃 수정

### DIFF
--- a/src/pages/SharedItemPage/SharedItem.style.ts
+++ b/src/pages/SharedItemPage/SharedItem.style.ts
@@ -4,28 +4,29 @@ import { MOBILE } from '@/constants';
 import { Col } from '@/styles/globalStyles';
 
 export const SharedItemWrapper = styled(Col)`
-  width: 70%;
+  width: 80%;
+  max-width: 120rem;
   align-items: center;
   margin: 0 auto;
+  padding: 3rem 0;
   gap: 3rem;
+
   @media screen and (max-width: ${MOBILE}px) {
+    padding: 2rem 0;
     width: 100%;
     gap: 1.5rem;
   }
 `;
 
 export const UserInfoWrapper = styled.div`
-  margin-top: 5rem;
   width: 100%;
-  @media screen and (max-width: ${MOBILE}px) {
-    margin-top: 1rem;
-  }
 `;
 
 export const SharedWrapper = styled(Col)`
   width: 100%;
   align-items: center;
   gap: 3rem;
+
   @media screen and (max-width: ${MOBILE}px) {
     width: 90%;
     gap: 1.5rem;

--- a/src/pages/SharedItemPage/SharedItem.tsx
+++ b/src/pages/SharedItemPage/SharedItem.tsx
@@ -49,7 +49,7 @@ const SharedItem = () => {
         <UserInfoWrapper>
           <UserInfoCard
             userImage={user.profileImage}
-            userName={user.email}
+            userName={user.nickname}
             tags={user.memberTags}
             links={user.snsList}
           />

--- a/src/pages/SharedPage/Shared.style.ts
+++ b/src/pages/SharedPage/Shared.style.ts
@@ -4,23 +4,27 @@ import { MOBILE, MOBILE_FONT_SIZE, WEB_FONT_SIZE } from '@/constants';
 import { Col, Row } from '@/styles/globalStyles';
 
 export const SharedWrapper = styled(Col)`
-  width: 70%;
+  width: 80%;
+  max-width: 120rem;
   margin: 0 auto;
+  padding: 3rem 0;
   gap: 3rem;
 
   @media screen and (max-width: ${MOBILE}px) {
     width: 90%;
     gap: 1.5rem;
+    margin: 0 auto;
+    padding: 2rem 0;
   }
 `;
 
 export const TagFilterWrapper = styled(Row)`
   width: 100%;
-  margin: 5rem auto;
+  margin-bottom: 5rem;
   justify-content: center;
 
   @media screen and (max-width: ${MOBILE}px) {
-    margin: 2rem auto;
+    margin-bottom: 2rem;
   }
 `;
 
@@ -34,7 +38,6 @@ export const SearchWrapper = styled(Row)`
 `;
 
 export const SelectorWrapper = styled(Row)`
-  margin: 1rem 0;
   justify-content: end;
 `;
 

--- a/src/pages/SharedPage/Shared.style.ts
+++ b/src/pages/SharedPage/Shared.style.ts
@@ -8,7 +8,7 @@ export const SharedWrapper = styled(Col)`
   max-width: 120rem;
   margin: 0 auto;
   padding: 3rem 0;
-  gap: 3rem;
+  gap: 2rem;
 
   @media screen and (max-width: ${MOBILE}px) {
     width: 90%;
@@ -20,12 +20,8 @@ export const SharedWrapper = styled(Col)`
 
 export const TagFilterWrapper = styled(Row)`
   width: 100%;
-  margin-bottom: 5rem;
+  margin-bottom: 2rem;
   justify-content: center;
-
-  @media screen and (max-width: ${MOBILE}px) {
-    margin-bottom: 2rem;
-  }
 `;
 
 export const SearchWrapper = styled(Row)`

--- a/src/pages/SharedPage/Shared.style.ts
+++ b/src/pages/SharedPage/Shared.style.ts
@@ -46,6 +46,7 @@ export const CardWrapper = styled.div`
 
   @media screen and (max-width: 1000px) {
     grid-template-columns: repeat(1, 1fr);
+    row-gap: 2rem;
   }
 `;
 


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용

# 📷스크린샷(필요 시)
### 꾸러미 페이지
<img width="1710" alt="image" src="https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/81172451/15066b00-9a2a-482f-abdb-07f9cd4a142e">

### 꾸러미 상세 페이지
<img width="1710" alt="image" src="https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/81172451/92fb6640-e20a-4663-907f-dc679cea52e6">

직접들어가서 확인하시는게 더 좋을거 같긴하지만 사진 남겨요!
##
# ✨PR Point
- `max-width`: 1200px로 고정하였습니다.
- 컨텐츠의 `width` 영역을 웹에선 80%, 모바일에선 90%로 지정하였습니다.
- `navBar`와의 간격을 웹에서 3rem, 모바일에서 2rem으로 지정하였습니다.

@SoJuSo 태그필터와의 검색바와의 간격이 좀 더 있었으면해서 태그필터에서 `margin-bottom: 5rem` 정도를 주었습니다.
허브페이지에서도 통일하면 좋을거같아서 의견 맞춰봅시다 ! 