### PR TITLE
[#268] 메인, 로그인, 회원가입 페이지 레이아웃 및 UI 수정

### DIFF
--- a/src/components/common/SearchBar/SearchBar.tsx
+++ b/src/components/common/SearchBar/SearchBar.tsx
@@ -39,6 +39,7 @@ const SearchBar = ({
   maxWidth,
   REGISTER,
   VALIDATE,
+  isOnlyBorderBottom = false,
 }: SearchBarProps) => {
   const {
     register,
@@ -68,14 +69,14 @@ const SearchBar = ({
           fontSize={fontSize}
           placeholder={'검색어를 입력해주세요.'}
           style={{
-            padding: '1rem 5rem 1rem 1rem',
+            padding: '2rem 5rem 2rem 1.5rem',
             height: isMobileSize ? '3rem' : '4rem',
           }}
           {...register(REGISTER, VALIDATE)}
           errorMessage={
             errors[REGISTER] ? errors[REGISTER]?.message?.toString() : ''
           }
-          isOnlyBorderBottom={false}
+          isOnlyBorderBottom={isOnlyBorderBottom}
         />
       </form>
       <IconWrapper

--- a/src/components/common/SearchBar/SearchBar.type.ts
+++ b/src/components/common/SearchBar/SearchBar.type.ts
@@ -6,6 +6,7 @@ export interface SearchBarProps extends React.HTMLAttributes<HTMLInputElement> {
   maxWidth?: string;
   REGISTER: string;
   VALIDATE?: RegisterOptions;
+  isOnlyBorderBottom?: boolean;
 }
 
 export interface SearchBarStyleProps {

--- a/src/components/common/UserInfoCard/UserInfoCard.style.ts
+++ b/src/components/common/UserInfoCard/UserInfoCard.style.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { BORDER_CARD_WEB, FONT_BOLD, FONT_REGULAR, MOBILE } from '@/constants';
+import { FONT_BOLD, FONT_REGULAR, MOBILE } from '@/constants';
 import { Col, Row } from '@/styles/globalStyles';
 
 export const UserInfoWrapper = styled(Row)`
@@ -13,7 +13,6 @@ export const UserInfoWrapper = styled(Row)`
   padding: 2rem;
   box-sizing: border-box;
   align-items: center;
-  /* border-radius: ${BORDER_CARD_WEB}rem; */
   border-radius: 0.8rem;
 
   & > :nth-child(1),

--- a/src/components/common/UserInfoCard/UserInfoCard.style.ts
+++ b/src/components/common/UserInfoCard/UserInfoCard.style.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { FONT_BOLD, FONT_REGULAR, MOBILE } from '@/constants';
+import { BORDER_CARD_WEB, FONT_BOLD, FONT_REGULAR, MOBILE } from '@/constants';
 import { Col, Row } from '@/styles/globalStyles';
 
 export const UserInfoWrapper = styled(Row)`
@@ -13,8 +13,8 @@ export const UserInfoWrapper = styled(Row)`
   padding: 2rem;
   box-sizing: border-box;
   align-items: center;
-  /* TODO: constans의 card_border로 수정 */
-  border-radius: 1.5rem;
+  /* border-radius: ${BORDER_CARD_WEB}rem; */
+  border-radius: 0.8rem;
 
   & > :nth-child(1),
   & > :nth-child(3) {
@@ -63,7 +63,7 @@ export const UserInfoBadgeWrapper = styled.div`
 `;
 
 export const UserInfoLinkWrapper = styled(Col)`
-  width: 100%;
+  width: fit-content;
   margin-top: 1rem;
   gap: 1rem;
 `;
@@ -73,11 +73,12 @@ export const UserInfoLink = styled(Row)`
     font-size: 1rem;
   }
 
-  width: 100%;
+  width: fit-content;
   color: ${({ theme }) => theme.primary_color};
   font-size: 1.2rem;
   gap: 0.5rem;
   align-items: center;
+  cursor: pointer;
   & > a {
     width: 100%;
     color: ${({ theme }) => theme.gray_400};

--- a/src/components/common/UserInfoCard/UserInfoCard.tsx
+++ b/src/components/common/UserInfoCard/UserInfoCard.tsx
@@ -111,7 +111,10 @@ const UserInfoCard = ({
             {links.length !== 0 ? (
               links.map((link, index) => (
                 <UserInfoLink key={index}>
-                  <IconWrapper $size={isMobileSize ? 'xss' : 'xs'}>
+                  <IconWrapper
+                    $size={isMobileSize ? 'xss' : 'xs'}
+                    style={{ cursor: 'default' }}
+                  >
                     <IoIosLink />
                   </IconWrapper>
                   <a

--- a/src/components/common/UserInfoCard/UserInfoCard.tsx
+++ b/src/components/common/UserInfoCard/UserInfoCard.tsx
@@ -97,6 +97,7 @@ const UserInfoCard = ({
                     $text={tag.name}
                     style={{
                       backgroundColor: `${theme.symbol_secondary_color}`,
+                      cursor: 'default',
                     }}
                     key={index}
                   />

--- a/src/pages/AuthPage/Auth.style.ts
+++ b/src/pages/AuthPage/Auth.style.ts
@@ -7,8 +7,14 @@ import { AuthPageStyleProps } from './Auth.type';
 
 export const AuthPageWrapper = styled(Row)`
   width: 80%;
-  margin: 6rem auto 0 auto;
+  max-width: 1200px;
+  margin: 3rem auto;
   align-items: center;
+
+  @media screen and (max-width: ${MOBILE}px) {
+    width: 80%;
+    margin: 2rem auto;
+  }
 `;
 
 export const AuthLogo = styled(Row)`
@@ -22,12 +28,9 @@ export const AuthLogo = styled(Row)`
 
 export const AuthContentWrapper = styled(Col)`
   width: 60%;
-  padding: 0 5rem;
-  margin-bottom: 3rem;
 
   @media screen and (max-width: ${MOBILE}px) {
     width: 100%;
-    padding: 0;
   }
 `;
 

--- a/src/pages/AuthPage/Auth.style.ts
+++ b/src/pages/AuthPage/Auth.style.ts
@@ -12,7 +12,7 @@ export const AuthPageWrapper = styled(Row)`
   align-items: center;
 
   @media screen and (max-width: ${MOBILE}px) {
-    width: 80%;
+    width: 90%;
     margin: 2rem auto;
   }
 `;

--- a/src/pages/MainPage/Main.style.ts
+++ b/src/pages/MainPage/Main.style.ts
@@ -5,11 +5,12 @@ import { Col } from '@/styles/globalStyles';
 
 export const MainPageWrapper = styled(Col)`
   width: 80%;
-  margin: 4rem auto;
+  max-width: 1200px;
+  margin: 3rem auto;
 
   @media screen and (max-width: ${MOBILE}px) {
     width: 90%;
-    margin: 3rem auto 0 auto;
+    margin: 2rem auto;
   }
 `;
 
@@ -47,7 +48,6 @@ export const MainItemWrapper = styled(Col)`
 
   @media screen and (max-width: ${MOBILE}px) {
     width: 100%;
-    margin-bottom: 1.5rem;
     gap: 2rem;
     align-items: center;
   }
@@ -91,5 +91,5 @@ export const HorizontalDivider = styled.hr`
   display: block;
   width: 100%;
   height: 0.1rem;
-  margin: 2rem 0;
+  margin: 4rem 0;
 `;

--- a/src/pages/RegisterPage/Register.style.ts
+++ b/src/pages/RegisterPage/Register.style.ts
@@ -7,9 +7,14 @@ export const RegisterPageWrapper = styled.div`
   display: flex;
   flex-direction: row;
   width: 80%;
-  margin: 6rem auto 0 auto;
+  max-width: 1200px;
+  margin: 3rem auto;
+  gap: 10rem;
 
   @media screen and (max-width: ${MOBILE}px) {
+    width: 80%;
+    margin: 2rem auto;
+    gap: 3rem;
     flex-direction: column;
     font-size: 2.8rem;
   }
@@ -51,11 +56,9 @@ export const RegisterHeader = styled.div`
 
 export const RegisterFormWrapper = styled(Col)`
   width: 60%;
-  margin-bottom: 3rem;
 
   @media screen and (max-width: ${MOBILE}px) {
     width: 100%;
-    padding: 0;
   }
 `;
 

--- a/src/pages/RegisterPage/Register.style.ts
+++ b/src/pages/RegisterPage/Register.style.ts
@@ -12,7 +12,7 @@ export const RegisterPageWrapper = styled.div`
   gap: 10rem;
 
   @media screen and (max-width: ${MOBILE}px) {
-    width: 80%;
+    width: 90%;
     margin: 2rem auto;
     gap: 3rem;
     flex-direction: column;


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용

메인, 로그인, 회원가입 페이지의 레이아웃을 합의된 사항으로 수정했습니다.
UserInfoCard, SearchBar 컴포넌트의 수정사항을 반영했습니다.

# 📷스크린샷(필요 시)
### Main
![스크린샷 2024-03-13 오전 11 23 27](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/087671d0-df42-4823-90af-835b4e09814f)
![스크린샷 2024-03-13 오전 11 23 38](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/9e6e6bfc-43ad-4139-8baa-fdf4395e5993)

### Auth
![스크린샷 2024-03-13 오전 11 24 08](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/c8136390-b2b0-42b1-ac0c-62c7e3bf3933)
![스크린샷 2024-03-13 오전 11 24 16](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/b7990b2a-2776-418d-be43-d616953f7363)

### Register
![스크린샷 2024-03-13 오전 11 24 45](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/372ba5ad-4534-4dd8-9f28-829109d5d9c8)
![스크린샷 2024-03-13 오전 11 24 35](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/de04c984-0629-470b-b487-f5d60f5bff8c)

### SearchBar
![스크린샷 2024-03-13 오전 11 25 20](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/113894a4-8d98-4bd3-a905-5db1f9ff8c0c)


# ✨PR Point
- 로그인, 회원가입 페이지에서는 위, 아래 네브바가 제거되기 때문에 로컬에서 임의로 제거 후 테스트 해봤는데 어색한 부분은 없었습니다 !!
- UserInfoCard, SearchBar 컴포넌트의 수정사항이 많지 않아서 해당 PR에서 같이 올리게 됐습니다 !
