### PR TITLE
[#305] 회원가입 과정 버그 hotfix

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import Router from '@/routes';
 
@@ -11,7 +10,6 @@ import { getItem } from './utils/localStorage';
 const App = () => {
   const { accessToken, setAccessToken, setUserData, setIsLogin } =
     userDataStore();
-  const navigator = useNavigate();
 
   const Auth = async () => {
     const refreshToken = getItem('refresh-token', null);
@@ -21,10 +19,6 @@ const App = () => {
         setAccessToken(res.accessToken);
         const userData = await getMyInfo();
         if (userData) {
-          if (!userData.nickname) {
-            navigator('/register');
-            return;
-          }
           setIsLogin(true);
           setUserData(userData);
         } else {

--- a/src/components/Main/InfoUpdateModal/InfoUpdateModal.const.ts
+++ b/src/components/Main/InfoUpdateModal/InfoUpdateModal.const.ts
@@ -32,4 +32,8 @@ export const NICKNAME_VALIDATION = {
     value: 2,
     message: '사용자 ID는 2자 이상 작성해주세요.',
   },
+  maxLength: {
+    value: 50,
+    message: '사용자 ID는 50자까지 작성 가능합니다.',
+  },
 };

--- a/src/components/Main/InfoUpdateModal/InfoUpdateModal.const.ts
+++ b/src/components/Main/InfoUpdateModal/InfoUpdateModal.const.ts
@@ -1,4 +1,4 @@
-import { URLREGEX } from '@/constants/validation';
+import { NICKNAMEREGEX, URLREGEX } from '@/constants/validation';
 
 export const MODAL = {
   TITLE: '사용자 정보 수정',
@@ -23,4 +23,13 @@ export const MODAL = {
 
 export const MODAL_LINK_VALIDATION = {
   pattern: URLREGEX,
+};
+
+export const NICKNAME_VALIDATION = {
+  required: true,
+  pattern: NICKNAMEREGEX,
+  minLength: {
+    value: 2,
+    message: '사용자 ID는 2자 이상 작성해주세요.',
+  },
 };

--- a/src/components/Main/InfoUpdateModal/InfoUpdateModal.tsx
+++ b/src/components/Main/InfoUpdateModal/InfoUpdateModal.tsx
@@ -13,7 +13,11 @@ import useResize from '@/hooks/useResize';
 import { Row } from '@/styles/globalStyles';
 import { Tag } from '@/types';
 
-import { MODAL, MODAL_LINK_VALIDATION } from './InfoUpdateModal.const';
+import {
+  MODAL,
+  MODAL_LINK_VALIDATION,
+  NICKNAME_VALIDATION,
+} from './InfoUpdateModal.const';
 import { useUpdateImage, useUpdateMyInfo } from './InfoUpdateModal.hook';
 import {
   ButtonContainer,
@@ -75,7 +79,7 @@ const InfoUpdateModal = ({
     const tagIds = selectedTags.map((tag) => tag.id);
 
     onUpdateInfo({
-      nickname: originalNickname,
+      nickname: `@${getValues('updateNickname')}`,
       snsRequests: updateSnsRequests,
       tagIds,
     });
@@ -129,11 +133,19 @@ const InfoUpdateModal = ({
       <form onSubmit={handleSubmit(onUpdateInfoForm)}>
         <div style={{ marginBottom: '1.8rem' }}>
           <Input
-            {...register('updateNickname')}
+            {...register('updateNickname', NICKNAME_VALIDATION)}
             width="100%"
             label={MODAL.USER_ID_LABEL}
             placeholder={MODAL.USER_ID_PLACEHOLDER}
-            isDisabled={true}
+            errorMessage={
+              errors?.updateNickname?.type === 'required'
+                ? '사용자 ID를 입력해주세요.'
+                : errors?.updateNickname?.type === 'pattern'
+                  ? '사용자 ID는 영어와 숫자 조합으로 작성해주세요.'
+                  : errors?.updateNickname?.type === 'minLength'
+                    ? '사용자 ID는 2자 이상 작성해주세요.'
+                    : ''
+            }
           />
         </div>
         <div style={{ marginBottom: '1.8rem' }}>

--- a/src/components/Main/InfoUpdateModal/InfoUpdateModal.tsx
+++ b/src/components/Main/InfoUpdateModal/InfoUpdateModal.tsx
@@ -144,7 +144,9 @@ const InfoUpdateModal = ({
                   ? '사용자 ID는 영어와 숫자 조합으로 작성해주세요.'
                   : errors?.updateNickname?.type === 'minLength'
                     ? '사용자 ID는 2자 이상 작성해주세요.'
-                    : ''
+                    : errors?.updateNickname?.type === 'maxLength'
+                      ? '사용자 ID는 50자까지 작성 가능합니다.'
+                      : ''
             }
           />
         </div>

--- a/src/components/common/UserInfoCard/UserInfoCard.hook.tsx
+++ b/src/components/common/UserInfoCard/UserInfoCard.hook.tsx
@@ -13,7 +13,7 @@ export const useInfoUpdateModal = () => {
   const { nickname, snsList, memberTags, profileImage } = userDataStore();
   const { setModalOpen } = useModal();
 
-  const handleInfoUpdateClick = () => {
+  const handleInfoUpdateModal = () => {
     setModalOpen({
       title: MODAL.TITLE,
       content: (
@@ -27,7 +27,7 @@ export const useInfoUpdateModal = () => {
     });
   };
 
-  return { handleInfoUpdateClick };
+  return { handleInfoUpdateModal };
 };
 
 export const useLogout = () => {

--- a/src/components/common/UserInfoCard/UserInfoCard.tsx
+++ b/src/components/common/UserInfoCard/UserInfoCard.tsx
@@ -56,7 +56,7 @@ const UserInfoCard = ({
   const theme = useTheme();
 
   const { isMobileSize } = useResize();
-  const { handleInfoUpdateClick } = useInfoUpdateModal();
+  const { handleInfoUpdateModal } = useInfoUpdateModal();
   const { mutate: logout } = useLogout();
   const storedRefreshToken = getItem('refresh-token', null);
 
@@ -131,7 +131,7 @@ const UserInfoCard = ({
           <UserInfoIconWrapper>
             <IconWrapper
               $size={isMobileSize ? 'xs' : 's'}
-              onClick={handleInfoUpdateClick}
+              onClick={handleInfoUpdateModal}
             >
               <PiNotePencil />
             </IconWrapper>

--- a/src/pages/AuthPage/Auth.tsx
+++ b/src/pages/AuthPage/Auth.tsx
@@ -20,7 +20,13 @@ import {
 const Auth = () => {
   const { isMobileSize } = useResize();
   const { isDarkMode } = themeStore();
-  const { accessToken: storedAccessToken, setAccessToken } = userDataStore();
+  const {
+    accessToken: storedAccessToken,
+    setAccessToken,
+    setIsLogin,
+    setIsFirstLogin,
+    setNickname,
+  } = userDataStore();
   const storedRefreshToken = getItem('refresh-token', null);
   const theme = useTheme();
 
@@ -32,6 +38,10 @@ const Auth = () => {
   const refreshToken = new URL(window.location.href).searchParams.get(
     'refresh-token'
   );
+  const isFirstLogin = new URL(window.location.href).searchParams.get(
+    'isFirstLogin'
+  );
+  const nickname = new URL(window.location.href).searchParams.get('nickname');
 
   const goGoogleLogin = () => {
     window.location.href = import.meta.env.VITE_GOOGLE_URL;
@@ -39,9 +49,16 @@ const Auth = () => {
 
   useEffect(() => {
     if (!storedAccessToken && !storedRefreshToken) {
-      if (accessToken && refreshToken) {
+      if (accessToken && refreshToken && isFirstLogin && nickname) {
         setAccessToken(accessToken);
         setItem('refresh-token', refreshToken);
+        {
+          isFirstLogin === 'true'
+            ? setIsFirstLogin(true)
+            : setIsFirstLogin(false);
+        }
+        setNickname(nickname);
+        setIsLogin(true);
         navigate('/');
       }
     } else {
@@ -54,6 +71,11 @@ const Auth = () => {
     refreshToken,
     storedAccessToken,
     storedRefreshToken,
+    isFirstLogin,
+    setIsFirstLogin,
+    nickname,
+    setIsLogin,
+    setNickname,
   ]);
 
   if (storedAccessToken || storedRefreshToken) {

--- a/src/pages/RegisterPage/Register.hook.ts
+++ b/src/pages/RegisterPage/Register.hook.ts
@@ -13,7 +13,7 @@ export const useUpdateMyInfo = () => {
         if (res.includes('400')) {
           notify({
             type: 'warning',
-            text: '사용자 아이디가 중복됐습니다.',
+            text: '사용자 ID가 중복됐습니다.',
           });
         }
       } else {

--- a/src/pages/RegisterPage/Register.tsx
+++ b/src/pages/RegisterPage/Register.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
@@ -15,7 +16,7 @@ import { useFetchTags } from '@/hooks/useFetchTags';
 import useResize from '@/hooks/useResize';
 import { themeStore, userDataStore } from '@/stores';
 import { Tag } from '@/types';
-import { getItem, setItem } from '@/utils/localStorage';
+import { getItem, removeItem, setItem } from '@/utils/localStorage';
 
 import {
   REGISTER_LINK_VALIDATION,
@@ -42,6 +43,7 @@ const Register = () => {
     register,
     handleSubmit,
     getValues,
+    setFocus,
     formState: { errors },
   } = useForm<RegisterForm>({
     mode: 'onChange',
@@ -97,6 +99,27 @@ const Register = () => {
     'refresh-token'
   );
 
+  const preventGoBack = () => {
+    history.pushState(null, '', location.href);
+    if (
+      confirm(
+        '회원 가입 정보가 저장되지 않았습니다. 해당 페이지를 벗어나시겠습니까?'
+      )
+    ) {
+      removeItem('refresh-token');
+      setAccessToken('');
+      navigate('/');
+    }
+  };
+
+  useEffect(() => {
+    history.pushState(null, '', location.href);
+    window.addEventListener('popstate', preventGoBack);
+    return () => {
+      window.removeEventListener('popstate', preventGoBack);
+    };
+  }, []);
+
   useEffect(() => {
     if (accessToken && refreshToken) {
       setAccessToken(accessToken);
@@ -110,7 +133,9 @@ const Register = () => {
     ) {
       navigate('/');
     }
-  }, [navigate, nickname, accessToken, setAccessToken, refreshToken]);
+
+    setFocus('nickname');
+  }, [navigate, setFocus, nickname, accessToken, setAccessToken, refreshToken]);
 
   return (
     <>
@@ -147,22 +172,6 @@ const Register = () => {
             </RegisterHeader>
           </RegisterIntro>
           <RegisterFormWrapper>
-            <RegisterItemWrapper>
-              <RegisterLabel>관심 분야</RegisterLabel>
-              {tagsLoading ? (
-                <Skeleton.Box
-                  $width={'100%'}
-                  $height={'20rem'}
-                />
-              ) : (
-                <TagFilter
-                  selectedTags={selectedTags}
-                  setSelectedTags={setSelectedTags}
-                  tagList={tags ?? []}
-                  isLimit={true}
-                />
-              )}
-            </RegisterItemWrapper>
             <form onSubmit={handleSubmit(handleRegisterSubmit)}>
               <RegisterItemWrapper>
                 <Input
@@ -219,6 +228,22 @@ const Register = () => {
                 />
               </RegisterItemWrapper>
             </form>
+            <RegisterItemWrapper>
+              <RegisterLabel>관심 분야</RegisterLabel>
+              {tagsLoading ? (
+                <Skeleton.Box
+                  $width={'100%'}
+                  $height={'20rem'}
+                />
+              ) : (
+                <TagFilter
+                  selectedTags={selectedTags}
+                  setSelectedTags={setSelectedTags}
+                  tagList={tags ?? []}
+                  isLimit={true}
+                />
+              )}
+            </RegisterItemWrapper>
             <RegisterCheckboxWrapper>
               <RegisterCheckbox
                 type="checkbox"

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -17,7 +17,6 @@ import {
   MyBundlePage,
   NotFoundPage,
   PolicyPage,
-  RegisterPage,
   ReportPage,
   SharedItemPage,
   SharedPage,
@@ -44,10 +43,6 @@ const Router = () => {
             <Route
               path={PATH.AUTH} // 로그인, 회원가입 페이지
               element={<AuthPage />}
-            />
-            <Route
-              path={PATH.REGISTER} // 회원가입 후 등록 페이지
-              element={<RegisterPage />}
             />
             <Route
               path={PATH.HUB} // 질문 허브 페이지(검색)

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -57,6 +57,9 @@ interface UserDataStoreType {
   memberTags: MemberTag[];
   accessToken: string;
   isLogin: boolean;
+  isFirstLogin: boolean;
+  setIsFirstLogin: (newIsFirstLogin: boolean) => void;
+  setNickname: (newNickname: string) => void;
   setAccessToken: (newAccessToken: string) => void;
   setIsLogin: (newIsLogin: boolean) => void;
   setUserData: (userData: UserDataSetType) => void;
@@ -78,10 +81,15 @@ export const userDataStore = create<UserDataStoreType>((set) => ({
   memberTags: [],
   accessToken: '',
   isLogin: false,
+  isFirstLogin: false,
+  setNickname: (newNickname: string) => set({ nickname: newNickname }),
   setAccessToken: (newAccessToken: string) =>
     set({ accessToken: newAccessToken }),
   setIsLogin: (newIsLogin: boolean) => {
     set({ isLogin: newIsLogin });
+  },
+  setIsFirstLogin: (newIsFirstLogin: boolean) => {
+    set({ isFirstLogin: newIsFirstLogin });
   },
   setUserData: (userData: UserDataSetType) =>
     set({


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
## `24.03.15 금요일` 항목부터 봐주시면 됩니다 :) 아래로 내리면 있어요 !!
@SoJuSo @kim-hyunjoo @pkb9239

# 📝작업 내용

서비스 로그인 시 정보 입력을 안하고 뒤로가기 버튼을 눌렀을 때 MainPage에서 무한으로 Spinner 컴포넌트가 출력되는 문제를 해결했습니다.

문제가 되는 부분은 아래와 같았습니다.
- 서비스 로그인 후, 브라우저에 포커스를 주지 않은 상태에서 뒤로가기 버튼을 눌렀을 땐 `구글 로그인 -> /auth?access-token=~~ -> / -> (/ 에서 자동으로 넘어옴) /register`의 과정으로 되돌아오는 문제가 생기진 않았습니다.
- **서비스 로그인 후, 브라우저에 포커스를 준 상태 (화면 클릭 등)에서 뒤로가기 버튼을 눌렀을 땐 `/` 로 바로 넘어가져서** 무한으로 Spinner 컴포넌트가 출력됐습니다. (메인 페이지에선 닉네임이 없는 유저는 /register 페이지로 넘겨주는 과정에서 생기는 화면 깜빡임을 방지하기 위해 `리프레시 토큰이 존재하고 닉네임이 없다면 Spinner 컴포넌트를 출력`시켜주고 있습니다.)

MainPage에서 해당 문제를 처리해주기엔 AuthPage, RegisterPage, MainPage 세 군데에서 인증 관련 확인 및 처리를 해주게 되는 구조이기 때문에 MainPage에서는 저장된 유저 정보를 이용한 조건부 렌더링만 실시하도록 하고 AuthPage, RegisterPage에서만 인증 관련 확인 및 처리를 하는 것이 바람직하다고 생각하여 `RegisterPage`에서 뒤로가기 기능을 제한하는 방법을 채택했습니다.
- 다만 브라우저 정책 상 `브라우저에 포커스가 가지 않은 상태에선 popstate 이벤트가 발생하지 않고 그대로 뒤로가기가 되기 때문에` 아래 스크린샷 초반부에선 /register로 넘어온 뒤, 화면 포커스(클릭)을 하지 않은 상태에선 뒤로가기가 동작하게 됩니다. 테스트 해본 결과 문제되는 부분은 없었으나 제가 확인하지 못한 케이스가 있을 수 있기 때문에 팀원분들이 테스트 해보고 오류가 발생하는 부분이 있다면 바로 말씀 부탁드립니다 !

뒤로가기 버튼을 누른다면 `회원 가입 정보가 저장되지 않았습니다. 해당 페이지를 벗어나시겠습니까?` 컨펌 창이 뜨고 확인을 누르면 저장된 refresh-token, access-token을 삭제하고 `/`로 리다이렉트 됩니다.

# 📷스크린샷(필요 시)

https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/df3ffae1-5aaf-4084-bf12-3700e36b28d4

# ✨PR Point

설명에서 느끼셨듯이 인증 관련 처리가 여러 군데에서 복잡하게 되고 있기도 하고, 말끔하지 않은 상태 입니다. 1차 배포를 위해 현재 구조를 유지하되, 버그를 수정하는 방향을 우선시 했습니다. 
멘토님께 자문도 구하고, 다른 서비스들은 인증 관련 처리를 어떻게 하는지 더 알아본 후 인증 처리 관련 로직들을 전면 수정 할 계획입니다....!

인증 관련 처리 작업이 처음이라 미숙한 부분이 많네요....ㅠㅠ 로그인, 회원가입이 제대로 안되면 팀원분들이 잘 만들어 주신 거 다 소용 없어지기 때문에 빠르게 처리 해보겠습니다 ㅠㅠ

---

# 24.03.15 금요일
멘토님 의견을 들은 후 아예 `/register`로 가는 경우를 없애고, 구글 로그인 후 리다이렉트 URL은 모두 베이스 URL을 `/`로 하고 최초 로그인 유무를 받아서 회원정보 수정 모달로 처리 하는 방법으로 적용하려고 합니다 ! 백엔드분들께 수정사항 요청 드리고 반영되는 대로 바로 작업 할게요 !

---
# 24.03.19 화요일
# 📝작업 내용
커밋 번호 `f548b26` 부터 보시면 됩니다 !

서비스 최초 로그인 시 메인 페이지에서 `유저 정보 수정 모달`이 바로 뜨도록 작업했습니다.
초기 닉네임은 `kiwing-{UUID}` 으로 설정됩니다.

- 로그인 하게되면 쿼리 스트링으로 `access-token, refresh-token, isFirstLogin, nickname` 정보가 들어오고, 4개의 정보를 Zustand 유저 정보 store에 저장한 뒤 `/`로 리다이렉트 되는 구조입니다.
isFirstLogin의 true/false 에 따라 `/`로 리다이렉트 후 유저 정보 수정 모달이 뜨는 구조입니다.

- 유저 정보 수정 모달의 사용자 ID부분에 validation을 적용했습니다.

- 사용자 ID 길이를 2자 이상 50자 이하로 설정했습니다.

- `/register` 라우터 삭제했습니다.

# 📷스크린샷(필요 시)

빈 계정이 없어서 테스트 영상은 첨부하지 못했습니다..ㅠ

# ✨PR Point
- 새로운 계정으로 서비스 최초 로그인 시 바로 뜨는 모달을 닫았을 때 (정보 수정 버튼을 누르지 않았을 때) 오류가 안나는지 테스트를 못 해서 테스트 가능하신 팀원분들 있으면 테스트 한번만 부탁 드리겠습니다 !