### PR TITLE
[#303] PWA 환경에서 발생하는 아이폰, 안드로이드 디바이슈 에러 핸들링

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,6 +129,26 @@
 
       gtag('config', 'G-JY80LMCG5P');
     </script>
+    <script>
+      if (
+        /Android/i.test(navigator.userAgent) &&
+        /Chrome/i.test(navigator.userAgent) &&
+        window.matchMedia('(display-mode: standalone)').matches
+      ) {
+        window.addEventListener('popstate', function () {
+          const location = window.location;
+          const isBackActive =
+            location.pathname !== '/shared' &&
+            !location.pathname.includes(`/user/`) &&
+            location.pathname !== '/hub' &&
+            location.pathname !== '/';
+
+          if (!isBackActive) {
+            window.history.pushState({ noBackExitsApp: true }, '');
+          }
+        });
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0"
+      content="width=device-width, initial-scale=1.0 viewport-fit=cover"
     />
 
     <link

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -13,7 +13,7 @@ const Layout = styled.main`
     width: 100%;
     height: 100%;
     padding-top: 5rem;
-    padding-bottom: 6rem;
+    padding-bottom: calc(6rem + env(safe-area-inset-bottom));
   }
 `;
 

--- a/src/components/common/Navigator/MobileBottomNavBar/MobileBottomNavBar.style.ts
+++ b/src/components/common/Navigator/MobileBottomNavBar/MobileBottomNavBar.style.ts
@@ -19,7 +19,9 @@ export const BottomNavBarWrapper = styled.nav`
 
   max-width: ${MOBILE}px;
   min-width: ${MOBILE_MIN - 10}px;
-  height: 6rem;
+
+  padding-bottom: env(safe-area-inset-bottom);
+  height: calc(6rem + env(safe-area-inset-bottom));
   width: 100%;
   white-space: nowrap;
   user-select: none;

--- a/src/components/common/Navigator/MobileTopNavBar/MobileTopNavBar.tsx
+++ b/src/components/common/Navigator/MobileTopNavBar/MobileTopNavBar.tsx
@@ -1,5 +1,5 @@
 import { MdArrowBack, MdDarkMode, MdLightMode } from 'react-icons/md';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { themeStore, userDataStore } from '@/stores';
 
@@ -10,21 +10,54 @@ import { TopBarItem, TopNavBarWrapper } from './MobileTopNavBar.style';
 
 const MobileTopNavBar = () => {
   const { isDarkMode, updateTheme } = themeStore();
+  const location = useLocation();
   const navigator = useNavigate();
-  const { isLogin, profileImage } = userDataStore();
+  const { isLogin, profileImage, nickname } = userDataStore();
   const { handleMyBundle } = useNavigatorMenu();
+
+  const isBackActive =
+    location.pathname !== '/shared' &&
+    location.pathname !== `/user/${nickname}` &&
+    location.pathname !== '/hub' &&
+    location.pathname !== '/';
+
+  const ShowBackButton = (path: string) => {
+    switch (path) {
+      case '/':
+        return 'HOME';
+      case '/shared':
+        return '공유된 꾸러미';
+      case '/hub':
+        return '질문 허브';
+    }
+
+    if (path.includes(`/user/${nickname}`)) {
+      return `내 꾸러미`;
+    }
+  };
 
   return (
     <TopNavBarWrapper $isDark={isDarkMode}>
       <TopBarItem>
-        <IconWrapper
-          onClick={() => {
-            navigator(-1);
-          }}
-          $size={'s'}
-        >
-          <MdArrowBack />
-        </IconWrapper>
+        {isBackActive ? (
+          <IconWrapper
+            onClick={() => {
+              navigator(-1);
+            }}
+            $size={'s'}
+          >
+            <MdArrowBack />
+          </IconWrapper>
+        ) : (
+          <div
+            style={{
+              fontSize: '2rem',
+              fontWeight: '550',
+            }}
+          >
+            {ShowBackButton(location.pathname)}
+          </div>
+        )}
       </TopBarItem>
       <TopBarItem>
         {isDarkMode ? (


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용
- 아이폰 환경에서의 safeArea를 대응하였습니다.
- 안드로이드 환경에서 사용자가 하단 내비게이션 바 위치 중에 존재하는 경우 뒤로가기 시 앱이 종료되는 동작을 추가하였습니다.
- 하단 내비게이션 바 위치에 존재할 때 뒤로가기 버튼이 아닌 현재 위치를 보여주도록 변경하였습니다.

# ✨PR Point
- safeArea 테스트 부탁드립니다. 아이폰 형님들,,, 다만 개별 코드로직에서 바꿀 필요는 없는 것으로 에뮬레이터 상에서는 확인했습니다!
- 안드로이드 일 경우 하단 내비게이션 바 path로 이동할 시 `window.history.pushState({ noBackExitsApp: true }, '');` 를 브라우저 히스토리에 push하여 바로 앱이 종료되도록 수정하였습니다.