### PR TITLE
[#309] questionCard v1.1.1

### DIFF
--- a/src/components/common/QuestionCard/QuestionCard.tsx
+++ b/src/components/common/QuestionCard/QuestionCard.tsx
@@ -1,5 +1,3 @@
-import { useEffect } from 'react';
-
 import useDropDown from '@/hooks/useDropDown';
 import useResize from '@/hooks/useResize';
 
@@ -10,7 +8,6 @@ import ShadowBox from '../ShadowBox';
 import { QuestionCardConstants } from './QuestionCard.const';
 import {
   useCreateQuestionsToBundle,
-  useGetMyBundles,
   useReportModal,
 } from './QuestionCard.hook';
 import {
@@ -23,7 +20,11 @@ import {
   QuestionCardReportBadge,
   QuestionCardText,
 } from './QuestionCard.style';
-import { QuestionCardProps } from './QuestionCard.type';
+import {
+  BundleParsed,
+  BundleResult,
+  QuestionCardProps,
+} from './QuestionCard.type';
 
 /**
  * @summary 사용법                 
@@ -44,15 +45,6 @@ import { QuestionCardProps } from './QuestionCard.type';
  * @param isLogin: boolean;
  * @returns
  */
-interface BundleParsed {
-  id: number;
-  name: string;
-}
-
-interface BundleResult {
-  id: number;
-  name: string;
-}
 
 const QuestionCard = ({
   id,
@@ -61,6 +53,7 @@ const QuestionCard = ({
   shareCount,
   isHot,
   isLogin,
+  Bundle,
 }: QuestionCardProps) => {
   const { isMobileSize } = useResize();
   const { handleReportClick } = useReportModal({ questionId: id });
@@ -76,13 +69,7 @@ const QuestionCard = ({
     });
   };
 
-  const { data: userBundles, refetch: getMyBundlesRefetch } =
-    useGetMyBundles('LATEST');
   const { mutate } = useCreateQuestionsToBundle();
-
-  useEffect(() => {
-    isLogin && getMyBundlesRefetch();
-  }, [getMyBundlesRefetch, isLogin]);
 
   const handleAdd = (checkedItems: number[]) => {
     mutate({ ids: [id], checkedBundles: checkedItems });
@@ -110,11 +97,11 @@ const QuestionCard = ({
               id={triggerId}
               onClick={openDropDown}
             />
-            {userBundles && (
+            {Bundle && (
               <DropDown
                 width={20}
                 height={15}
-                options={transType(userBundles)}
+                options={transType(Bundle)}
                 isShow={isShow}
                 setIsShow={setIsShow}
                 mode="checkbox"

--- a/src/components/common/QuestionCard/QuestionCard.type.tsx
+++ b/src/components/common/QuestionCard/QuestionCard.type.tsx
@@ -7,4 +7,15 @@ export interface QuestionCardProps {
   isHot: boolean;
   tags: Tag[];
   isLogin: boolean;
+  Bundle: BundleParsed[];
+}
+
+export interface BundleParsed {
+  id: number;
+  name: string;
+}
+
+export interface BundleResult {
+  id: number;
+  name: string;
 }

--- a/src/pages/HubPage/Hub.tsx
+++ b/src/pages/HubPage/Hub.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { SyncLoader } from 'react-spinners';
 import { useTheme } from 'styled-components';
@@ -10,6 +10,7 @@ import {
   NO_SEARCH_RESULTS_IMAGE,
 } from '@/components/common/NoSearchResults/NoSearchResults.const';
 import QuestionCard from '@/components/common/QuestionCard';
+import { useGetMyBundles } from '@/components/common/QuestionCard/QuestionCard.hook';
 import SearchBar from '@/components/common/SearchBar';
 import Selector from '@/components/common/Selector';
 import TagFilter from '@/components/common/TagFilter';
@@ -64,6 +65,13 @@ const Hub = () => {
     }
   };
 
+  const { data: userBundles, refetch: getMyBundlesRefetch } =
+    useGetMyBundles('LATEST');
+
+  useEffect(() => {
+    isLogin && getMyBundlesRefetch();
+  }, [getMyBundlesRefetch, isLogin]);
+
   return (
     <>
       <HubLayout>
@@ -113,6 +121,7 @@ const Hub = () => {
                     shareCount={questionItem.shareCount}
                     isHot={questionItem.isHot}
                     isLogin={isLogin}
+                    Bundle={userBundles ? userBundles : []}
                   />
                 )
               );

--- a/src/pages/MainPage/Main.tsx
+++ b/src/pages/MainPage/Main.tsx
@@ -1,5 +1,8 @@
+import { useEffect } from 'react';
+
 import BundleCard from '@/components/common/BundleCard';
 import QuestionCard from '@/components/common/QuestionCard';
+import { useGetMyBundles } from '@/components/common/QuestionCard/QuestionCard.hook';
 import Spinner from '@/components/common/Spinner';
 import UserInfoCard from '@/components/common/UserInfoCard';
 import useResize from '@/hooks/useResize';
@@ -42,6 +45,13 @@ const Main = () => {
     tagIds: [],
   });
 
+  const { data: userBundles, refetch: getMyBundlesRefetch } =
+    useGetMyBundles('LATEST');
+
+  useEffect(() => {
+    isLogin && getMyBundlesRefetch();
+  }, [getMyBundlesRefetch, isLogin]);
+
   return (
     <>
       {storedRefreshToken && !nickname ? (
@@ -76,6 +86,7 @@ const Main = () => {
                       shareCount={question.shareCount}
                       isHot={question.isHot}
                       isLogin={isLogin}
+                      Bundle={userBundles ? userBundles : []}
                     />
                   </MainQuestionsBox>
                 ))}


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용
QuestionCard에서 bundle 목록을 불러오는 로직을 수정했습니다.

## 문제점
기존에는 각 카드마다 bundle 목록을 불러와서 비효율적인 네트워크 요청이 상당히 발생하였습니다.
![image](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/90549862/125fea5c-0a07-4a97-8d2d-2060bca223da)

이를 해결하기 위해 상단 페이지 단에서 한 번만 호출하고 해당 데이터를 내려주는 방식으로 변경하여 해결하였습니다.
해결 후에는 이제 한 번만 호출되는 것을 확인하실 수 있습니다.
![image](https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/90549862/00102ea8-8512-4e23-bd1c-a2ff7674a650)

# ✨PR Point
@JaeHyunGround 제가 메인에도 로직 추가했습니다!