### PR TITLE
[#337] SharedItemPage v1.2.0

### DIFF
--- a/src/components/SharedBundle/SharedBundleCard/SharedBundleCard.style.ts
+++ b/src/components/SharedBundle/SharedBundleCard/SharedBundleCard.style.ts
@@ -11,7 +11,7 @@ export const SharedBundleCardWrapper = styled.div`
 export const BundleTitle = styled.section`
   font-size: 2rem;
   padding: 2rem;
-  font-weight: ${FONT_MEDIUM};
+  font-weight: ${FONT_MEDIUM - 50};
   width: 70%;
   text-align: center;
   color: ${({ theme }) => theme.primary_white_text_color};

--- a/src/pages/SharedItemPage/SharedItem.hook.ts
+++ b/src/pages/SharedItemPage/SharedItem.hook.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { getBundleDetail } from '@/services/bundles';
-import { Bundle, BundleDetailRequest } from '@/types';
+import { Bundle, BundleDetailRequest, Question } from '@/types';
 
 export const useGetBundleDetail = ({
   bundleId,
@@ -12,4 +12,10 @@ export const useGetBundleDetail = ({
     queryFn: () => getBundleDetail({ bundleId, showOnlyMyQuestions }),
   });
   return query;
+};
+
+export const useLatestQuestions = (questions: Question[] | null) => {
+  return questions?.sort(
+    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+  );
 };

--- a/src/pages/SharedItemPage/SharedItem.tsx
+++ b/src/pages/SharedItemPage/SharedItem.tsx
@@ -5,7 +5,7 @@ import UserInfoCard from '@/components/common/UserInfoCard';
 import SharedBundleBox from '@/components/SharedBundle/SharedBundleBox';
 import SharedBundleCard from '@/components/SharedBundle/SharedBundleCard';
 
-import { useGetBundleDetail } from './SharedItem.hook';
+import { useGetBundleDetail, useLatestQuestions } from './SharedItem.hook';
 import {
   SharedItemWrapper,
   SharedWrapper,
@@ -17,9 +17,7 @@ const SharedItem = () => {
   const bundleId = Number(params.id);
   const { data: detail } = useGetBundleDetail({ bundleId: bundleId });
   const questions = detail?.questions;
-  const latestQuestions = questions?.sort(
-    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
-  );
+  const latestQuestions = useLatestQuestions(questions ?? null);
 
   if (!questions || !latestQuestions) {
     return <Spinner />;

--- a/src/pages/SharedItemPage/SharedItem.tsx
+++ b/src/pages/SharedItemPage/SharedItem.tsx
@@ -1,12 +1,9 @@
-import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import Spinner from '@/components/common/Spinner';
 import UserInfoCard from '@/components/common/UserInfoCard';
 import SharedBundleBox from '@/components/SharedBundle/SharedBundleBox';
 import SharedBundleCard from '@/components/SharedBundle/SharedBundleCard';
-import { getUserInfo } from '@/services/members';
-import { UserInfoResponse } from '@/types';
 
 import { useGetBundleDetail } from './SharedItem.hook';
 import {
@@ -19,27 +16,12 @@ const SharedItem = () => {
   const params = useParams();
   const bundleId = Number(params.id);
   const { data: detail } = useGetBundleDetail({ bundleId: bundleId });
-  const [user, setUser] = useState<UserInfoResponse | null>(null);
-
-  useEffect(() => {
-    const fetchUser = async () => {
-      if (detail && detail.writerId) {
-        const userData: UserInfoResponse | null = await getUserInfo(
-          detail.writerId
-        );
-        setUser(userData);
-      }
-    };
-    fetchUser();
-  }, [detail]);
-
   const questions = detail?.questions;
-
   const latestQuestions = questions?.sort(
     (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
   );
 
-  if (!questions || !user || !latestQuestions) {
+  if (!questions || !latestQuestions) {
     return <Spinner />;
   }
 
@@ -48,10 +30,10 @@ const SharedItem = () => {
       <SharedItemWrapper>
         <UserInfoWrapper>
           <UserInfoCard
-            userImage={user.profileImage}
-            userName={user.nickname}
-            tags={user.memberTags}
-            links={user.snsList}
+            userImage={detail.writer.profileImage}
+            userName={detail.writer.nickname}
+            tags={detail.writer.memberTags}
+            links={detail.writer.snsList}
           />
         </UserInfoWrapper>
         <SharedWrapper>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -169,7 +169,7 @@ export interface Bundle {
   createdAt: string;
   updatedAt: string;
   questions: Question[];
-  writerId: number;
+  writer: UserInfoResponse;
 }
 
 export interface BundlesUpdateResponse extends BundlesBasic {}


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용
꾸머리 상세 api의 구조가 바뀜에 따라서 코드 로직을 변경하였습니다.
기존의 원래는 유저정보를 상세 api에서 writerId를 이용해서 유정정보를 가져왔다면 이제는 상세 조회만으로 writer 데이터를 이용해서 유저정보를 가져와 사용할수있게되었습니다.
- 디자인 피드백을 통해 공유된번들카드의 titlte 글씨 굵기를 500 => 450으로 수정하였습니다.
- 그리고 type/index.ts 에서 Bundle 타입을 수정하였습니다. 확인부탁드려요!
# ✨PR Point
현재 로컬 서버에서 꾸러미 상세 페이지가 보이지않으므로 빠르게 코드리뷰 부탁드립니당 ! !