### PR TITLE
[#359] Toast 컴포넌트  v1.0.1

### DIFF
--- a/src/hooks/toast.tsx
+++ b/src/hooks/toast.tsx
@@ -43,7 +43,7 @@ const Toast = () => {
       newestOnTop
       closeOnClick
       rtl={false}
-      pauseOnFocusLoss
+      pauseOnFocusLoss={false}
       pauseOnHover={false}
       theme={isDarkMode ? 'dark' : 'light'}
       toastStyle={{

--- a/src/hooks/toast.tsx
+++ b/src/hooks/toast.tsx
@@ -38,14 +38,19 @@ const Toast = () => {
     <ToastContainer
       position="top-center"
       autoClose={autoClose}
-      hideProgressBar={false}
+      hideProgressBar={isMobileSize ? true : false}
       stacked={isMobileSize ? false : true}
+      newestOnTop
       closeOnClick
       rtl={false}
       pauseOnFocusLoss
       pauseOnHover={false}
       theme={isDarkMode ? 'dark' : 'light'}
-      style={{ fontSize: isMobileSize ? '1.3rem' : '1.6rem' }}
+      toastStyle={{
+        borderRadius: '12px',
+        margin: isMobileSize ? '1rem 2rem' : '0',
+        fontSize: isMobileSize ? '1.3rem' : '1.6rem',
+      }}
     />
   );
 };


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용

Toast 컴포넌트를 수정했습니다.
- 모바일 환경에서 toast 알림이 화면 너비를 다 차지하는 문제를 해결했습니다.
- 화면 포커스를 잃어도 toast close 시간이 흐르도록 옵션을 수정했습니다.
- 모바일 환경에서는 progressBar를 숨겼고, 데스크톱 환경에서는 progressBar를 출력해줬습니다.

# 📷스크린샷(필요 시)

https://github.com/Team-kiwing/Team-3seco-kiwing-fe/assets/97944429/67a1923d-b24b-414c-ab55-d2208ed9dc84

# ✨PR Point
- 자료를 더 찾아보고 `모바일 환경에서 알림이 쌓이는 구조`로 리펙토링 해보겠습니다 !!