### PR TITLE
[#383] PWA 오프라인 감지 로직 수정

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -86,15 +86,26 @@
         });
       }
 
-      document.getElementById('network-status').innerText = `${
-        prefersKorean
-          ? navigator.onLine
-            ? ' 온라인'
-            : ' 오프라인'
-          : navigator.onLine
-            ? ' online'
-            : ' offline'
-      }`;
+      function checkOnlineStatus() {
+        return fetch('https://www.google.com', {
+          method: 'HEAD',
+          mode: 'no-cors',
+        })
+          .then(() => true)
+          .catch(() => false);
+      }
+
+      checkOnlineStatus().then((isOnline) => {
+        document.getElementById('network-status').innerText = `${
+          prefersKorean
+            ? isOnline
+              ? ' 온라인'
+              : ' 오프라인'
+            : isOnline
+              ? ' online'
+              : ' offline'
+        }`;
+      });
     </script>
   </body>
 </html>

--- a/public/serviceWorker.js
+++ b/public/serviceWorker.js
@@ -1,5 +1,5 @@
 // 캐시 이름
-const CACHE_NAME = 'kiwing-cache-v1.0.2';
+const CACHE_NAME = 'kiwing-cache-v1.0.3';
 
 // 캐싱할 파일
 const FILES_TO_CACHE = ['/offline.html', '/favicon.ico'];


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->
# 📝작업 내용
- PWA 오프라인 감지 로직을 수정하였습니다.
- 서비스워커 배포 버전을 업데이트 하였습니다.

# ✨PR Point
kiwing서버에 연결되지 않을 경우에 PWA에서 offline.html 페이지를 보여주게 됩니다.
<img src="https://github.com/user-attachments/assets/71f48ef4-474e-4712-8c47-1f27e84d5a21" width="50%" height="50%"/>
다만 이때 현재 사용자 네트워크 문제인지, 서버 문제인지 감지할 수 있도록 구분하는 로직을 넣어두었었습니다.

기존 방식은 `navigator.onLine`방식으로 브라우저 내비게이터에 내장되어 있는 네트워크 감지로직입니다.
하지만 이 로직은 두 가지 문제점이 있습니다..!

첫 번째로 정확성입니다. 예를 들어 wifi가 연결되어 있지만, wifi의 호스트의 네트워크가 동작하지 않아 외부 인터넷에 연결할 수 없는 경우에도 와이파이에 연결된 상태이기에 `navigator.onLine`는 true를 반환합니다. 즉, 사용자 네트워크의 변경을 제대로 감지하는 데에는 한계가 있습니다.

두 번째로 일부 브라우저에서는 동작하지 않을 수도 있다는 점입니다. 크로스 브라우징을 위반하게 됩니다.

이러한 이유로 기존의 로직을 대체하여 조금 더 확실한 방법으로 네트워크를 감지하기 위해 아래와 같이 google에 접속을 시도하여 접속 여부를 boolean값을 반환하는 로직으로 변경하였습니다.
```js
      function checkOnlineStatus() {
        return fetch('https://www.google.com', {
          method: 'HEAD',
          mode: 'no-cors',
        })
          .then(() => true)
          .catch(() => false);
      }
```

이상입니다!